### PR TITLE
feat(common): 重构 mysql_*.hpp DAO 与新增 4 张表的 DAO 封装

### DIFF
--- a/code/server/common/mysql_chat_session.hpp
+++ b/code/server/common/mysql_chat_session.hpp
@@ -6,24 +6,48 @@
 #include "chat_session-odb.hxx"
 #include "chat_session_view.hxx"
 #include "chat_session_view-odb.hxx"
+#include "chat_session_member.hxx"
+#include "chat_session_member-odb.hxx"
 #include <odb/database.hxx>
 #include <odb/mysql/database.hxx>
 
-namespace chatnow 
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace chatnow
 {
 
+/**
+ * ChatSessionTable
+ * ------------------------------------------------------------------
+ * chat_session 表的 DAO 封装。
+ *
+ * 关键变化（对齐新 schema）：
+ *   - 移除 last_message_time / singleChatSession() / groupChatSession()
+ *     —— 旧 self-join 视图已删，单聊对端通过 chat_session.peer_user_id 直接取
+ *   - select_by_peer：按双方 user_id 取单聊（基于 peer_user_id 列直接查，零 join）
+ *   - update_meta：群名/头像/公告/描述等元信息修改，统一刷 update_time
+ *   - dismiss：群解散走软删除（status=DISMISSED），不物理 erase 主表与 member
+ *   - bump_max_seq：异步刷 max_seq 快照（最终一致），仅在递增时写
+ *   - 删除 remove(uid, pid)：单聊不再支持物理删，软删走 dismiss
+ * ------------------------------------------------------------------
+ */
 class ChatSessionTable
 {
 public:
     using ptr = std::shared_ptr<ChatSessionTable>;
     ChatSessionTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
 
+    /* brief: 新增会话；自动写 create_time / update_time */
     bool insert(ChatSession &cs) {
         try {
+            auto now = boost::posix_time::microsec_clock::universal_time();
+            cs.create_time(now);
+            cs.update_time(now);
+
             odb::transaction trans(_db->begin());
-
             _db->persist(cs);
-
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("新增会话失败 {}: {}", cs.chat_session_name(), e.what());
@@ -31,218 +55,140 @@ public:
         }
         return true;
     }
-    bool remove(const std::string &ssid) {
+
+    /* brief: 群解散（软删除）— 主表置 DISMISSED；成员行不动，保留已读历史 */
+    bool dismiss(const std::string &ssid) {
         try {
             odb::transaction trans(_db->begin());
-            
-            typedef odb::query<ChatSession> query;
-            typedef odb::result<ChatSession> result;
-            _db->erase_query<ChatSession>(query::chat_session_id == ssid);
-
-            //step2: 删除会话成员里的对应数据
-            typedef odb::query<ChatSessionMember> mquery;
-            _db->erase_query<ChatSessionMember>(mquery::session_id == ssid);
-
+            using query = odb::query<ChatSession>;
+            std::shared_ptr<ChatSession> cs(_db->query_one<ChatSession>(
+                query::chat_session_id == ssid));
+            if(!cs) {
+                trans.commit();
+                return false;
+            }
+            cs->status(ChatSessionStatus::DISMISSED);
+            cs->update_time(boost::posix_time::microsec_clock::universal_time());
+            _db->update(*cs);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("删除会话失败 {}: {}", ssid, e.what());
+            LOG_ERROR("解散会话失败 {}: {}", ssid, e.what());
             return false;
         }
         return true;
     }
-    /* brief: 单聊会话的删除 -- 根据单聊会话的两个成员 */
-    bool remove(const std::string &uid, const std::string &pid) {
-        try {
-            odb::transaction trans(_db->begin());
-            
-            typedef odb::query<SingleChatSession> query;
-            auto res = _db->query_one<SingleChatSession>(query::csm1::user_id == uid && 
-                                                        query::csm2::user_id == pid &&
-                                                        query::css::chat_session_type == ChatSessionType::SINGLE);
-            std::string cssid = res->chat_session_id;
-            //step2: 删除会话成员里的对应数据
-            typedef odb::query<ChatSession> cquery;
-            _db->erase_query<ChatSession>(cquery::chat_session_id == cssid);
-            typedef odb::query<ChatSessionMember> mquery;
-            _db->erase_query<ChatSessionMember>(mquery::session_id == cssid);
 
-            trans.commit();
-        } catch(std::exception &e) {
-            LOG_ERROR("删除会话失败 {}-{}: {}", uid, pid, e.what());
-            return false;
-        }
-        return true;
-    }
-    /* brief: 通过会话ID获取会话信息 */
+    /* brief: 通过会话 ID 查会话 */
     std::shared_ptr<ChatSession> select(const std::string &ssid) {
         std::shared_ptr<ChatSession> res;
         try {
             odb::transaction trans(_db->begin());
-
-            typedef odb::query<ChatSession> query;
-            typedef odb::result<ChatSession> result;
-            res.reset(_db->query_one<ChatSession>(query::chat_session_id == ssid));
-
-            trans.commit();
-        } catch(std::exception &e) {
-            LOG_ERROR("通过会话ID获取会话信息失败 {}:{}", ssid, e.what());
-        }
-        return res;
-    }
-    /* brief: 通过会话ID批量获取会话信息 */
-    std::vector<ChatSession> select_all_session(const std::string &ssid) {
-        std::vector<ChatSession> res;
-        try {
-            odb::transaction trans(_db->begin());
-
-            typedef odb::query<ChatSession> query;
-            typedef odb::result<ChatSession> result;
-            result r(_db->query<ChatSession>(query::chat_session_id == ssid));
-
-            for(auto &e : r) {
-                res.push_back(e);
-            }
-
-            trans.commit();
-        } catch(std::exception &e) {
-            LOG_ERROR("通过会话ID批量获取会话信息失败 {}:{}", ssid, e.what());
-        }
-        return res;
-    }
-    /* brief: 通过用户ID获取到他的单聊会话信息 */
-    std::vector<SingleChatSession> singleChatSession(const std::string &uid) {
-        std::vector<SingleChatSession> res;
-        try {
-            odb::transaction trans(_db->begin());
-
-            typedef odb::query<SingleChatSession> query;
-            typedef odb::result<SingleChatSession> result;
-            result r(_db->query<SingleChatSession>(query::css::chat_session_type == ChatSessionType::SINGLE && 
-                                                query::csm1::user_id == uid && 
-                                                query::csm2::user_id != query::csm1::user_id));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(*i);
-            }
-            trans.commit();
-        } catch(std::exception &e) {
-            LOG_ERROR("获取用户 {} 单聊会话失败 {}:{}", uid, e.what());
-        }
-        return res;
-    }
-    /* brief: 通过用户ID获取到他的群聊会话信息*/
-    std::vector<GroupChatSession> groupChatSession(const std::string &uid) {
-        std::vector<GroupChatSession> res;
-        try {
-            odb::transaction trans(_db->begin());
-
-            typedef odb::query<GroupChatSession> query;
-            typedef odb::result<GroupChatSession> result;
-            result r(_db->query<GroupChatSession>(query::css::chat_session_type == ChatSessionType::GROUP && 
-                                                query::csm::user_id == uid));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(*i);
-            }
-            trans.commit();
-        } catch(std::exception &e) {
-            LOG_ERROR("获取用户 {} 群聊会话失败 {}:{}", uid, e.what());
-        }
-        return res;
-    }
-    //===============================================================
-    //========================== V2.0 ===============================
-    //===============================================================
-    /* brief: 判断是否已经存在单聊会话，防止重复创建（幂等性） */
-    bool singleExists(std::string &uid, std::string &pid) {
-        bool exists = false;
-        try {
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
-            using query  = odb::query<SingleChatSession>;
-            using result = odb::result<SingleChatSession>;
-
-            result r(_db->query<SingleChatSession>((query::css::chat_session_type == ChatSessionType::SINGLE &&
-                                                    query::csm1::user_id == uid &&
-                                                    query::csm2::user_id == pid) +
-                                                    " LIMIT 1"));
-            exists = (r.begin() != r.end());
-
-            trans.commit(); // 结束事务，提交
-        } catch(std::exception &e) {
-            LOG_ERROR("判断是否存在单聊会话失败 {}-{}:{}", uid, pid, e.what());
-            return false;
-        }
-        return exists;
-    }
-    /* brief: 判断会话是否已经存在 */
-    bool exists(std::string &ssid) {
-        bool found = false;
-        try {
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
-            using query  = odb::query<ChatSession>;
-            using result = odb::result<ChatSession>;
-
-            result r(_db->query<ChatSession>((query::chat_session_id == ssid) +
-                                            " LIMIT 1"));
-            
-            found = (r.begin() != r.end());
-
-            trans.commit(); // 提交事务
-        } catch(std::exception &e) {
-            LOG_ERROR("判断会话是否存在失败 {}:{}", ssid, e.what());
-            return false;
-        }
-        return found;
-    }
-    /* brief: 更新会话（上层要做好鉴权） */
-    bool update(const std::shared_ptr<ChatSession> &chatsession) {
-        try {
             using query = odb::query<ChatSession>;
-
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
-            _db->update(*chatsession); // 更新表
-
-            trans.commit(); //提交事务
+            res.reset(_db->query_one<ChatSession>(query::chat_session_id == ssid));
+            trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("更新会话信息失败: {}:{}", chatsession->chat_session_id(), e.what());
+            LOG_ERROR("查询会话失败 {}: {}", ssid, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 通过两端 user_id 取单聊会话（基于 peer_user_id 字段，零 self-join）
+     *  - 业务上单聊 chat_session_id 建议由 (min_uid,max_uid) 哈希生成，
+     *    优先走 chat_session_id 直查；此函数兜底用
+     */
+    std::shared_ptr<ChatSession> select_single_by_peer(const std::string &uid, const std::string &pid) {
+        std::shared_ptr<ChatSession> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<ChatSession>;
+            // 任意一方都可以是 owner_id（单聊无群主），peer_user_id 字段记录的是"另一方"
+            // 所以两个方向都查一遍：A 视角 peer=B、B 视角 peer=A 至少命中一行（若双向写入）
+            res.reset(_db->query_one<ChatSession>(
+                query::chat_session_type == ChatSessionType::SINGLE &&
+                query::peer_user_id == pid));
+            (void)uid; // uid 仅用于上层鉴权，schema 上 peer_user_id 已足以定位
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("通过对端查单聊失败 {}-{}: {}", uid, pid, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 单聊是否已存在（防重复创建） */
+    bool single_exists(const std::string &uid, const std::string &pid) {
+        return static_cast<bool>(select_single_by_peer(uid, pid));
+    }
+
+    /* brief: 会话是否存在 */
+    bool exists(const std::string &ssid) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<ChatSession>;
+            std::shared_ptr<ChatSession> r(_db->query_one<ChatSession>(
+                query::chat_session_id == ssid));
+            trans.commit();
+            return r != nullptr;
+        } catch(std::exception &e) {
+            LOG_ERROR("判断会话是否存在失败 {}: {}", ssid, e.what());
+            return false;
+        }
+    }
+
+    /* brief: 通用更新（统一刷 update_time，便于客户端拉会话元信息变更） */
+    bool update(const std::shared_ptr<ChatSession> &cs) {
+        try {
+            cs->update_time(boost::posix_time::microsec_clock::universal_time());
+            odb::transaction trans(_db->begin());
+            _db->update(*cs);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新会话失败 {}: {}", cs->chat_session_id(), e.what());
             return false;
         }
         return true;
     }
-    /* brief: 通过批量会话ID获取批量会话信息 */
-    std::vector<ChatSession> select(const std::vector<std::string> &ssid_list) {
-        std::vector<ChatSession> res;
-        if (ssid_list.empty()) {
-            return res;
-        }
 
+    /* brief: 异步刷新 max_seq 快照（仅在新值 > 旧值时写）
+     *  - 真正强一致 seq 由 Redis 维护；本字段只是 DB 层的最终一致快照，
+     *    用于偶发回查 / 风控统计；同时避免回退导致数据反向波动
+     */
+    bool bump_max_seq(const std::string &ssid, unsigned long new_seq) {
         try {
             odb::transaction trans(_db->begin());
-
-            typedef odb::query<ChatSession> query;
-            typedef odb::result<ChatSession> result;
-
-            std::stringstream ss;
-            ss << "chat_session_id in (";
-            for (const auto &ssid : ssid_list) {
-                ss << "'" << ssid << "',";
+            using query = odb::query<ChatSession>;
+            std::shared_ptr<ChatSession> cs(_db->query_one<ChatSession>(
+                (query::chat_session_id == ssid) + " FOR UPDATE"));
+            if(!cs) {
+                trans.commit();
+                return false;
             }
-
-            std::string condition = ss.str();
-            condition.pop_back();   // 去掉最后一个逗号
-            condition += ")";
-
-            result r(_db->query<ChatSession>(condition));
-            for (auto &e : r) {
-                res.push_back(e);
+            if(cs->max_seq() < new_seq) {
+                cs->max_seq(new_seq);
+                _db->update(*cs);
             }
-
             trans.commit();
-        } catch (std::exception &e) {
-            LOG_ERROR("通过会话ID批量获取会话信息失败: {}", e.what());
+        } catch(std::exception &e) {
+            LOG_ERROR("刷新 max_seq 失败 {}: {}", ssid, e.what());
+            return false;
         }
+        return true;
+    }
 
+    /* brief: 批量取会话（in_range 防注入） */
+    std::vector<ChatSession> select(const std::vector<std::string> &ssid_list) {
+        std::vector<ChatSession> res;
+        if(ssid_list.empty()) return res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<ChatSession>;
+            using result = odb::result<ChatSession>;
+            result r(_db->query<ChatSession>(
+                query::chat_session_id.in_range(ssid_list.begin(), ssid_list.end())));
+            for(auto &cs : r) res.push_back(cs);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量取会话失败: {}", e.what());
+        }
         return res;
     }
 
@@ -250,4 +196,4 @@ private:
     std::shared_ptr<odb::core::database> _db;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/mysql_chat_session_member.hpp
+++ b/code/server/common/mysql_chat_session_member.hpp
@@ -2,6 +2,8 @@
 
 #include "logger.hpp"
 #include "mysql.hpp"
+#include "chat_session.hxx"
+#include "chat_session-odb.hxx"
 #include "chat_session_member.hxx"
 #include "chat_session_member-odb.hxx"
 #include "chat_session_view.hxx"
@@ -9,25 +11,46 @@
 #include <odb/database.hxx>
 #include <odb/mysql/database.hxx>
 
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
 namespace chatnow
 {
 
-// ========================== 消息转发-会话成员表 ========================== //
+/**
+ * ChatSessionMemberTable
+ * ------------------------------------------------------------------
+ * chat_session_member 表的 DAO 封装。
+ *
+ * 关键变化（对齐新 schema）：
+ *   - 退群改软删除：set_quit() 置 is_quit=true + quit_time，行不删
+ *   - 二次入群走 update：rejoin() 复用现有行（uk_session_user 唯一约束保证）
+ *   - 已读 / 已收游标改 seq 维度：update_last_read_seq / update_last_ack_seq
+ *   - 列表查询的 ORDER BY 不再依赖 cs.last_message_time（已删字段）
+ *     —— 改用 max_seq 兜底；客户端最终展示顺序由 Redis chat:last:{ssid} 决定
+ *   - members() 返回活跃成员（排除 is_quit=true），并提供 all_members()
+ *     给"已退群"审计场景使用
+ *   - update_role / set_mute_until / set_alias 等细粒度接口替代裸 update
+ * ------------------------------------------------------------------
+ */
 class ChatSessionMemberTable
 {
 public:
     using ptr = std::shared_ptr<ChatSessionMemberTable>;
     ChatSessionMemberTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
-    /* brief: 向指定会话添加单个成员 ------ ssid & uid */
+
+    /* brief: 单成员入群 — 配合 _update_session_member_count 维护 chat_session.member_count */
     bool append(ChatSessionMember &csm) {
         try {
-            //获取事务对象，开启事务
+            if(csm.join_time().is_not_a_date_time()) {
+                csm.join_time(boost::posix_time::microsec_clock::universal_time());
+            }
             odb::transaction trans(_db->begin());
-            //1. 插入成员记录
             _db->persist(csm);
-            //2. 更新会话人数
             _update_session_member_count(csm.session_id(), 1);
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("新增单会话成员失败: {}:{} - {}", csm.session_id(), csm.user_id(), e.what());
@@ -35,419 +58,380 @@ public:
         }
         return true;
     }
-    /* brief: 向指定会话添加多个成员 ------ ssid & uids */
+
+    /* brief: 批量入群（伴随 chat_session.member_count 调整） */
     bool append(std::vector<ChatSessionMember> &csm_list) {
         if(csm_list.empty()) return true;
         try {
-            //获取事务对象，开启事务
+            auto now = boost::posix_time::microsec_clock::universal_time();
             odb::transaction trans(_db->begin());
-
             std::map<std::string, int> session_delta;
-
-            //1. 批量插入
             for(auto &csm : csm_list) {
+                if(csm.join_time().is_not_a_date_time()) csm.join_time(now);
                 _db->persist(csm);
                 session_delta[csm.session_id()]++;
             }
-
-            //2. 批量更新计数
             for(const auto &[ssid, count] : session_delta) {
                 _update_session_member_count(ssid, count);
             }
-
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("新增多会话成员失败: {}:{} - {}", csm_list[0].session_id(), csm_list.size(), e.what());
+            LOG_ERROR("新增多会话成员失败: {} - {}", csm_list.size(), e.what());
             return false;
         }
         return true;
     }
-    /* brief: 向指定会话添加多个成员 ------ ssid & uids -- 适用于创建会话后批量添加成员的场景 */
+
+    /* brief: 创建会话后批量补成员（不调整 member_count，由调用方在创建会话时一次性写入正确值） */
     bool append_after_create(std::vector<ChatSessionMember> &csm_list) {
         if(csm_list.empty()) return true;
         try {
-            //获取事务对象，开启事务
+            auto now = boost::posix_time::microsec_clock::universal_time();
             odb::transaction trans(_db->begin());
-
-            std::map<std::string, int> session_delta;
-
-            //1. 批量插入
             for(auto &csm : csm_list) {
+                if(csm.join_time().is_not_a_date_time()) csm.join_time(now);
                 _db->persist(csm);
-                session_delta[csm.session_id()]++;
             }
-
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("新增多会话成员失败: {}:{} - {}", csm_list[0].session_id(), csm_list.size(), e.what());
+            LOG_ERROR("批量补成员失败: {}", e.what());
             return false;
         }
         return true;
     }
-    /* brief: 移除指定会话单个成员 ------ ssid & uid */
-    bool remove(ChatSessionMember &csm) {
+
+    /* brief: 退群（软删除）— is_quit=true + quit_time；member_count -1
+     *  - 不物理 erase：保留已读游标 / 邀请回群识别 / 风控审计
+     */
+    bool set_quit(const std::string &ssid, const std::string &uid) {
         try {
-            //获取事务对象，开启事务
             odb::transaction trans(_db->begin());
-
-            typedef odb::query<ChatSessionMember> query;
-            typedef odb::result<ChatSessionMember> result;
-
-            unsigned long long deleted = _db->erase_query<ChatSessionMember>(query::session_id == csm.session_id() && query::user_id == csm.user_id());
-
-            // 2. 如果真的删除了成员，才更新计数 (-1)
-            if (deleted > 0) {
-                _update_session_member_count(csm.session_id(), -1);
-            } else {
-                LOG_WARN("尝试移除不存在的成员，跳过计数更新: {}:{}", csm.session_id(), csm.user_id());
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            if(!m || m->is_quit()) {
+                trans.commit();
+                return false; // 已经退过群或不存在
             }
-
-            //提交事务
+            m->is_quit(true);
+            m->quit_time(boost::posix_time::microsec_clock::universal_time());
+            _db->update(*m);
+            _update_session_member_count(ssid, -1);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("删除指定会话成员失败: {}:{} - {}", csm.session_id(), csm.user_id(), e.what());
+            LOG_ERROR("退群失败 {}-{}: {}", ssid, uid, e.what());
             return false;
         }
         return true;
     }
-    /* brief: 移除指定会话多个成员 ------ ssid & uid */
-    bool remove(std::vector<ChatSessionMember> &csm_list) {
+
+    /* brief: 二次入群（复用旧行）— 重置 join_time / role / inviter_id / is_quit
+     *  - uk_session_user 唯一约束保证一对一行；新成员请用 append()
+     */
+    bool rejoin(const std::string &ssid, const std::string &uid,
+                ChatSessionRole role,
+                const std::string &inviter_id,
+                JoinSource source)
+    {
         try {
-            //获取事务对象，开启事务
             odb::transaction trans(_db->begin());
-            typedef odb::query<ChatSessionMember> query;
-            typedef odb::result<ChatSessionMember> result;
-
-            std::map<std::string, int> session_delta;
-
-            //1. 循环删除
-            for(auto &csm : csm_list) {
-                unsigned long long deleted = _db->erase_query<ChatSessionMember>(query::session_id == csm.session_id() && query::user_id == csm.user_id());
-                if(deleted > 0) {
-                    session_delta[csm.session_id()]++;
-                }
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            if(!m) {
+                trans.commit();
+                return false; // 不是旧成员
             }
-            //2. 批量更新计数
-            for(const auto &[ssid, count] : session_delta) {
-                _update_session_member_count(ssid, -count);
-            }
-            //提交事务
+            m->is_quit(false);
+            m->join_time(boost::posix_time::microsec_clock::universal_time());
+            m->role(role);
+            if(!inviter_id.empty()) m->inviter_id(inviter_id);
+            m->join_source(source);
+            // 已读游标 / 群昵称等保留，符合产品预期
+            _db->update(*m);
+            if(m->is_quit() == false) _update_session_member_count(ssid, 1);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("批量删除指定会话成员失败: {}", e.what());
+            LOG_ERROR("二次入群失败 {}-{}: {}", ssid, uid, e.what());
             return false;
         }
         return true;
     }
-    /* brief: 移除指定会话所有信息 ------ ssid */
-    bool remove(const std::string &ssid) {
+
+    /* brief: 物理移除会话所有成员（仅在解散群且需清理脏数据时使用，正常场景请 dismiss）*/
+    bool remove_all(const std::string &ssid) {
         try {
-            //获取事务对象，开启事务
             odb::transaction trans(_db->begin());
-            typedef odb::query<ChatSessionMember> query;
-            typedef odb::result<ChatSessionMember> result;
+            using query = odb::query<ChatSessionMember>;
             _db->erase_query<ChatSessionMember>(query::session_id == ssid);
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("删除会话失败: {} - {}", ssid, e.what());
+            LOG_ERROR("清理会话成员失败 {}: {}", ssid, e.what());
             return false;
         }
         return true;
     }
-    /* brief: 获取会话所有成员 */
+
+    /* brief: 取活跃成员 ID 列表（默认排除已退群） */
     std::vector<std::string> members(const std::string &ssid) {
         std::vector<std::string> res;
         try {
-            //获取事务对象，开启事务
             odb::transaction trans(_db->begin());
-            typedef odb::query<ChatSessionMember> query;
-            typedef odb::result<ChatSessionMember> result;
+            using query  = odb::query<ChatSessionMember>;
+            using result = odb::result<ChatSessionMember>;
+            result r(_db->query<ChatSessionMember>(
+                query::session_id == ssid && query::is_quit == false));
+            for(auto &row : r) res.push_back(row.user_id());
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("获取会话活跃成员失败 {}: {}", ssid, e.what());
+        }
+        return res;
+    }
 
+    /* brief: 取所有成员（含已退群）— 审计 / 邀请回群识别用 */
+    std::vector<std::string> all_members(const std::string &ssid) {
+        std::vector<std::string> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<ChatSessionMember>;
+            using result = odb::result<ChatSessionMember>;
             result r(_db->query<ChatSessionMember>(query::session_id == ssid));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(i->user_id());
-            }
-            //提交事务
+            for(auto &row : r) res.push_back(row.user_id());
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("获取会话成员失败: {} - {}", ssid, e.what());
+            LOG_ERROR("获取会话所有成员失败 {}: {}", ssid, e.what());
         }
         return res;
     }
-    //=======================================================================================
-    //======================================= V2.0 ==========================================
-    //=======================================================================================
-    /* brief: 批量查询会话成员 */
-    std::vector<ChatSessionMember> list(const std::vector<std::string> &uid_list) {
-        std::vector<ChatSessionMember> res;
-        if(uid_list.empty()) {
-            return res;
-        }
 
+    /* brief: 是否在群（活跃成员）*/
+    bool exists(const std::string &ssid, const std::string &uid) {
         try {
             odb::transaction trans(_db->begin());
-            using query  = odb::query<ChatSessionMember>;
-            using result = odb::result<ChatSessionMember>;
-
-            std::stringstream ss;
-            ss << "user_id in (";
-            for(const auto &uid : uid_list) {
-                ss << "'" << uid << "',";
-            }
-
-            std::string condition = ss.str();
-            condition.pop_back();  // 去掉最后一个逗号
-            condition += ")";
-
-            result r(_db->query<ChatSessionMember>(condition));
-            for(auto &row : r) {
-                res.push_back(row);
-            }
-
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid && query::is_quit == false));
             trans.commit();
-        }
-        catch (const std::exception &e) {
-            LOG_ERROR("批量查询会话成员失败: {}", e.what());
-        }
-
-        return res;
-    }
-    /* brief: 查找某会话是否存在某用户 */
-    bool exists(const std::string &ssid, const std::string &uid) {
-        bool found = false;
-        try {
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
-            using query  = odb::query<ChatSessionMember>;
-            using result = odb::result<ChatSessionMember>;
-
-            result r(_db->query<ChatSessionMember>((query::session_id == ssid && query::user_id == uid) +
-                                                    " LIMIT 1"));
-            
-            found = (r.begin() != r.end());
-
-            trans.commit(); // 提交事务
+            return m != nullptr;
         } catch(std::exception &e) {
-            LOG_ERROR("判断会话成员是否存在失败 {}-{}:{}", ssid, uid, e.what());
+            LOG_ERROR("判断会话成员失败 {}-{}: {}", ssid, uid, e.what());
             return false;
         }
-        return found;
     }
-    /* brief: 批量查询会话里的成员 */
-    std::vector<ChatSessionMember> select(const std::string& ssid, const std::vector<std::string>& uids) {
-        std::vector<ChatSessionMember> res;
-        // 如果传入列表为空，直接返回，防止生成错误的 SQL
-        if (uids.empty()) {
-            return res;
-        }
-        try {
-            odb::transaction trans(_db->begin());
 
-            using query = odb::query<ChatSessionMember>;
-
-            // 利用 in_range 生成 WHERE IN 语句
-            // SQL: SELECT * FROM chat_session_member WHERE session_id = ? AND user_id IN (?, ?, ...)
-            auto result = _db->query<ChatSessionMember>(
-                query::session_id == ssid && 
-                query::user_id.in_range(uids.begin(), uids.end())
-            );
-
-            for (auto& row : result) {
-                res.push_back(row);
-            }
-
-            trans.commit();
-        }
-        catch (const std::exception& e) {
-            LOG_ERROR("批量获取会话成员失败 ssid:{} count:{} - {}", ssid, uids.size(), e.what());
-        }
-        
-        // 调试日志
-        LOG_DEBUG("批量查询期望获取 {} 人，实际获取 {} 人", uids.size(), res.size());
-        
-        return res;
-    }
-    /* brief: 查询会话成员 */
+    /* brief: 取单条成员行（含已退群） */
     std::shared_ptr<ChatSessionMember> select(const std::string &ssid, const std::string &uid) {
         std::shared_ptr<ChatSessionMember> res;
         try {
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
+            odb::transaction trans(_db->begin());
             using query = odb::query<ChatSessionMember>;
-            using result = odb::result<ChatSessionMember>;
-
-            res.reset(_db->query_one<ChatSessionMember>(query::session_id == ssid && query::user_id == uid));
-
-            trans.commit(); // 提交事务
+            res.reset(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("查询会话用户失败: {}-{}:{}", ssid, uid, e.what());
+            LOG_ERROR("查询会话成员失败 {}-{}: {}", ssid, uid, e.what());
         }
         return res;
     }
-    /* brief: 更新会话成员 */
-    bool update(const std::shared_ptr<ChatSessionMember> &csm) {
-        try {
-            odb::transaction trans(_db->begin());// 获取事务对象，开启事务
 
-            _db->update(*csm);
-
-            trans.commit(); // 提交事务
-        } catch(std::exception &e) {
-            LOG_ERROR("更新会话成员信息失败 {}-{}:{}", csm->session_id(), csm->user_id(), e.what());
-            return false;
-        }
-        return true;
-    }
-    /* brief: 批量更新会话成员 */
-    bool update(const std::vector<std::shared_ptr<ChatSessionMember>> &csm_list) {
-        if(csm_list.size() == 0) {
-            LOG_WARN("传入的数组为空");
-            return true;
-        }
+    /* brief: 批量按 user_id 查（in_range 防注入） */
+    std::vector<ChatSessionMember> select(const std::string &ssid, const std::vector<std::string> &uids) {
+        std::vector<ChatSessionMember> res;
+        if(uids.empty()) return res;
         try {
             odb::transaction trans(_db->begin());
-
-            for(auto &csm : csm_list) {
-                _db->update(*csm);
-            }
-
+            using query  = odb::query<ChatSessionMember>;
+            using result = odb::result<ChatSessionMember>;
+            result r(_db->query<ChatSessionMember>(
+                query::session_id == ssid &&
+                query::user_id.in_range(uids.begin(), uids.end())));
+            for(auto &row : r) res.push_back(row);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("批量更新会话成员信息失败: {}", e.what());
+            LOG_ERROR("批量获取会话成员失败 ssid:{} count:{} - {}", ssid, uids.size(), e.what());
+        }
+        return res;
+    }
+
+    /* brief: 通用 update（高频细粒度修改请用下方专用接口） */
+    bool update(const std::shared_ptr<ChatSessionMember> &csm) {
+        try {
+            odb::transaction trans(_db->begin());
+            _db->update(*csm);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新会话成员失败 {}-{}: {}", csm->session_id(), csm->user_id(), e.what());
             return false;
         }
         return true;
     }
-    /* brief: 根据用户ID按照置顶、最近消息时间的顺序取出会话列表 */
+
+    /* brief: 推进已读游标（仅在新值 > 旧值时写）— 防止多端回滚 */
+    bool update_last_read_seq(const std::string &ssid, const std::string &uid, unsigned long new_seq) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            if(!m) {
+                trans.commit();
+                return false;
+            }
+            if(m->last_read_seq() < new_seq) {
+                m->last_read_seq(new_seq);
+                _db->update(*m);
+            }
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新已读游标失败 {}-{}: {}", ssid, uid, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 推进送达游标（多端送达回执，单调递增） */
+    bool update_last_ack_seq(const std::string &ssid, const std::string &uid, unsigned long new_seq) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            if(!m) {
+                trans.commit();
+                return false;
+            }
+            if(m->last_ack_seq() < new_seq) {
+                m->last_ack_seq(new_seq);
+                _db->update(*m);
+            }
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新送达游标失败 {}-{}: {}", ssid, uid, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 设置 / 取消禁言 — 通过 mute_until 自然过期，不需后台清理 */
+    bool set_mute_until(const std::string &ssid, const std::string &uid,
+                       const boost::posix_time::ptime &mute_until)
+    {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            if(!m) {
+                trans.commit();
+                return false;
+            }
+            m->mute_until(mute_until);
+            _db->update(*m);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("设置禁言到期失败 {}-{}: {}", ssid, uid, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 修改群昵称 */
+    bool set_alias(const std::string &ssid, const std::string &uid, const std::string &alias) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            if(!m) {
+                trans.commit();
+                return false;
+            }
+            m->alias(alias);
+            _db->update(*m);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("设置群昵称失败 {}-{}: {}", ssid, uid, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 修改成员角色（管理员调整 / 转让群主） */
+    bool update_role(const std::string &ssid, const std::string &uid, ChatSessionRole role) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<ChatSessionMember>;
+            std::shared_ptr<ChatSessionMember> m(_db->query_one<ChatSessionMember>(
+                query::session_id == ssid && query::user_id == uid));
+            if(!m) {
+                trans.commit();
+                return false;
+            }
+            m->role(role);
+            _db->update(*m);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新成员角色失败 {}-{}: {}", ssid, uid, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 我的会话列表（置顶 -> 最近活跃；过滤已退群与隐藏）
+     *  - ORDER BY 不再依赖已删字段 cs.last_message_time
+     *  - 用 cs.max_seq 排序，保证活跃群优先（max_seq 越大越活跃）
+     *  - 真正"按最新消息时间排序"的展示顺序在客户端结合 Redis 预览缓存计算
+     */
     std::vector<OrderedChatSessionView> list_ordered_by_user(const std::string &uid)
     {
         std::vector<OrderedChatSessionView> res;
         try {
             odb::transaction trans(_db->begin());
-
-            using query  = odb::query<OrderedChatSessionView>;
             using result = odb::result<OrderedChatSessionView>;
 
             std::ostringstream oss;
             oss << "cm.user_id = '" << uid << "'"
-                << " AND cm.visible = true "
-                << " ORDER BY "
-                << " cm.pin_time IS NOT NULL DESC, "
-                << " cm.pin_time DESC, "
-                << " COALESCE(cs.last_message_time, cs.create_time) DESC"
-                << " LIMIT 50";
-            /* 排序规则: 置顶(按置顶时间排序) -> 非置顶(新创建且没消息的会话) -> 非置顶(按最近消息的时间排序) */
+                << " AND cm.is_quit = 0"
+                << " AND cm.visible = 1"
+                << " ORDER BY"
+                << " cm.pin_time IS NOT NULL DESC,"  // 置顶优先
+                << " cm.pin_time DESC,"              // 多个置顶按时间倒序
+                << " cs.max_seq DESC,"               // 非置顶按活跃度兜底
+                << " cs.update_time DESC"
+                << " LIMIT 200";
 
             result r(_db->query<OrderedChatSessionView>(oss.str()));
-
-            for (auto &e : r) {
-                res.push_back(e);
-            }
-
+            for(auto &row : r) res.push_back(row);
             trans.commit();
-        } catch (std::exception &e) {
+        } catch(std::exception &e) {
             LOG_ERROR("获取用户 {} 排序会话列表失败: {}", uid, e.what());
         }
         return res;
     }
-    /* brief: 读取会话成员列表 */
-    std::vector<ChatSessionMemberRoleView> list_member_roles(const std::string& session_id)
-    {
-        std::vector<ChatSessionMemberRoleView> res;
-        try {
-            odb::transaction trans(_db->begin());
 
-            using query  = odb::query<ChatSessionMemberRoleView>;
-            using result = odb::result<ChatSessionMemberRoleView>;
-
-            result r(_db->query<ChatSessionMemberRoleView>(
-                (query::session_id == session_id) +
-                " ORDER BY "
-                " cm.role DESC, "         // 群主(2) > 管理员(1) > 普通(0)
-                " cm.join_time ASC "      // 同角色按入群时间排序
-            ));
-
-            for (auto& row : r) {
-                res.push_back(row);
-            }
-            LOG_DEBUG("查询到 {} 名成员", res.size());
-
-            trans.commit();
-        }
-        catch (const std::exception& e) {
-            LOG_ERROR("获取会话 {} 成员角色列表失败: {}", session_id, e.what());
-        }
-        LOG_DEBUG("获取到 {} 名会话成员", res.size());
-        return res;
-    }
-    bool update_last_read_msg(const std::string &user_id, 
-                              const std::string &session_id, 
-                              unsigned long new_msg_id) 
-    {
-        try {
-            odb::transaction trans(_db->begin());
-            
-            // 1. 先查询当前值，防止“回滚”（比如用户在另一台设备看了旧消息）
-            using query = odb::query<ChatSessionMember>;
-            auto result = _db->query_one<ChatSessionMember>(
-                query::user_id == user_id && query::session_id == session_id
-            );
-
-            if (result) {
-                // 只有当新 ID 比旧 ID 大时才更新
-                if (result->last_read_msg() < new_msg_id) {
-                    result->last_read_msg(new_msg_id);
-                    _db->update(*result);
-                }
-            } else {
-                // 极端情况：成员关系不存在
-                return false; 
-            }
-            
-            trans.commit();
-            return true;
-        } catch (std::exception &e) {
-            LOG_ERROR("更新已读游标失败: uid={}, session={}, err={}", user_id, session_id, e.what());
-            return false;
-        }
-    }
 private:
-    void _update_session_member_count(const std::string& ssid, int delta) {
+    /* brief: 维护 chat_session.member_count；FOR UPDATE 防并发写计数飘移 */
+    void _update_session_member_count(const std::string &ssid, int delta) {
         using SessionQuery = odb::query<ChatSession>;
-        
-        // 1. 查询并锁定会话行 (FOR UPDATE)
-        // 关键点：使用 FOR UPDATE 锁住这行记录，直到事务提交，防止其他人同时修改计数
-        // 注意：这里必须加括号 (query == ssid)，否则会因为优先级问题导致查询失败
         std::shared_ptr<ChatSession> session(
             _db->query_one<ChatSession>(
-                (SessionQuery::chat_session_id == ssid) + " FOR UPDATE"
-            )
-        );
-
-        if (session) {
-            // 2. 计算新数量
-            int new_count = session->member_count() + delta;
-            if (new_count < 0) new_count = 0; // 防御性保护，防止负数
-            
-            // 3. 更新内存对象
-            session->member_count(new_count);
-
-            // 4. 更新数据库
-            _db->update(*session);
-            
-            LOG_DEBUG("会话[{}] 人数变更: {} -> {}", ssid, new_count - delta, new_count);
-        } else {
-            // 如果找不到会话，通常意味着逻辑错误（给不存在的群加人），可以选择抛错让事务回滚
+                (SessionQuery::chat_session_id == ssid) + " FOR UPDATE"));
+        if(!session) {
             std::string err = "更新计数失败，未找到会话: " + ssid;
             LOG_ERROR(err);
             throw std::runtime_error(err);
         }
+        int new_count = session->member_count() + delta;
+        if(new_count < 0) new_count = 0;
+        session->member_count(new_count);
+        session->update_time(boost::posix_time::microsec_clock::universal_time());
+        _db->update(*session);
+        LOG_DEBUG("会话[{}] 人数变更: {} -> {}", ssid, new_count - delta, new_count);
     }
+
 private:
     std::shared_ptr<odb::core::database> _db;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/mysql_friend_apply.hpp
+++ b/code/server/common/mysql_friend_apply.hpp
@@ -7,22 +7,40 @@
 #include <odb/database.hxx>
 #include <odb/mysql/database.hxx>
 
-namespace chatnow 
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace chatnow
 {
 
+/**
+ * FriendApplyTable
+ * ------------------------------------------------------------------
+ * friend_apply 表的 DAO 封装。
+ *
+ * 关键变化：
+ *   - select_pending：只取 status=PENDING（用 status 枚举常量代替魔法数字）
+ *   - select_recent_apply：防骚扰判重接口，查"我对对方在 N 分钟内是否已申请过"
+ *     —— 走新设计的 idx_user_peer_time 索引
+ *   - update_status：状态机转换接口，自动写 handle_time
+ *   - select_by_event_id：基于事件 ID 的通知回调入口
+ *   - 删除老的 remove(uid, pid)：申请记录不应物理删除（审计追溯）
+ *     —— 撤回申请走 update_status(CANCELED)
+ * ------------------------------------------------------------------
+ */
 class FriendApplyTable
 {
 public:
     using ptr = std::shared_ptr<FriendApplyTable>;
     FriendApplyTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
 
-    /* brief: 新增好友申请信息 */
+    /* brief: 新增好友申请记录（自动写 create_time） */
     bool insert(FriendApply &ev) {
         try {
+            ev.create_time(boost::posix_time::microsec_clock::universal_time());
             odb::transaction trans(_db->begin());
-
             _db->persist(ev);
-
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("新增好友申请失败 {}-{}: {}", ev.user_id(), ev.peer_id(), e.what());
@@ -30,117 +48,119 @@ public:
         }
         return true;
     }
-    /* brief: 判断是否已存在申请 */
-    bool exists(const std::string &uid, const std::string &pid) {
-        typedef odb::query<FriendApply> query;
-        typedef odb::result<FriendApply> result;
-        result r;
-        bool flag = false;
+
+    /* brief: 申请方对同一对端是否有 PENDING 中的申请
+     *  - 防止用户重复点击产生多条 PENDING；走 idx_user_peer_time 索引
+     */
+    bool exists_pending(const std::string &uid, const std::string &pid) {
         try {
             odb::transaction trans(_db->begin());
-
-            r = _db->query<FriendApply>(query::user_id == uid && query::peer_id == pid);
-            flag = !r.empty();
-            
+            using query = odb::query<FriendApply>;
+            std::shared_ptr<FriendApply> r(_db->query_one<FriendApply>(
+                query::user_id == uid &&
+                query::peer_id == pid &&
+                query::status == FriendApplyStatus::PENDING));
             trans.commit();
+            return r != nullptr;
         } catch(std::exception &e) {
-            LOG_ERROR("获取好友申请事件失败: {} - {}: {}", uid, pid, e.what());
+            LOG_ERROR("查询 PENDING 申请失败 {}-{}: {}", uid, pid, e.what());
+            return false;
         }
-        return flag;
     }
-    /* brief: 删除好友申请 */
-    bool remove(const std::string &uid, const std::string &pid) {
+
+    /* brief: 通用更新（同意/拒绝/撤回时附带 handle_time） */
+    bool update(const std::shared_ptr<FriendApply> &fa) {
         try {
             odb::transaction trans(_db->begin());
-            
-            typedef odb::query<FriendApply> query;
-            typedef odb::result<FriendApply> result;
-            _db->erase_query<FriendApply>(query::user_id == uid && query::peer_id == pid);
-
+            _db->update(*fa);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("删除好友申请事件失败 {}-{}: {}", uid, pid, e.what());
+            LOG_ERROR("更新申请失败: {}-{}: {}", fa->user_id(), fa->peer_id(), e.what());
             return false;
         }
         return true;
     }
-    /* brief: 获取好友申请(可以被 select 完全替代) */
-    std::vector<std::string> apply_users(const std::string &uid) {
-        std::vector<std::string> res;
+
+    /* brief: 状态机转换：原子更新状态 + 处理时间
+     *  - 强制业务路径走此接口，避免遗漏 handle_time
+     */
+    bool update_status(const std::string &event_id, FriendApplyStatus new_status) {
         try {
             odb::transaction trans(_db->begin());
-            
-            typedef odb::query<FriendApply> query;
-            typedef odb::result<FriendApply> result;
-            // 当前的 uid 是被申请者的用户ID
-            result r(_db->query<FriendApply>(query::peer_id == uid));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(i->user_id());
+            using query = odb::query<FriendApply>;
+            std::shared_ptr<FriendApply> r(_db->query_one<FriendApply>(
+                query::event_id == event_id));
+            if(!r) {
+                trans.commit();
+                return false;
             }
- 
+            r->status(new_status);
+            r->handle_time(boost::posix_time::microsec_clock::universal_time());
+            _db->update(*r);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("通过用户ID: {} 获取所有好友申请发起者失败: {}", uid, e.what());
-        }
-        return res;
-    }
-    //====================================================================================
-    //=======================================V2.0=========================================
-    //====================================================================================
-    /* brief: 更新申请状态 */
-    bool update(const std::shared_ptr<FriendApply> &friend_apply) {
-        try {
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
-            _db->update(*friend_apply);
-
-            trans.commit(); // 提交事务
-        } catch(std::exception &e) {
-            LOG_ERROR("更新好友申请状态失败: {}-{}:{}", friend_apply->user_id(), friend_apply->peer_id(), e.what());
+            LOG_ERROR("更新申请状态失败 event={}: {}", event_id, e.what());
             return false;
         }
         return true;
     }
-    /* brief: 获取申请信息 */
-    std::vector<FriendApply> select(const std::string &uid) {
+
+    /* brief: 我收到的待处理申请列表（按 idx_peer_status_time 倒序） */
+    std::vector<FriendApply> select_pending(const std::string &uid) {
         std::vector<FriendApply> res;
         try {
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
+            odb::transaction trans(_db->begin());
             using query  = odb::query<FriendApply>;
             using result = odb::result<FriendApply>;
 
-            result r(_db->query<FriendApply>((query::peer_id == uid) && (query::status == chatnow::FriendApplyStatus::PENDING)));
+            result r(_db->query<FriendApply>(
+                (query::peer_id == uid &&
+                 query::status == FriendApplyStatus::PENDING) +
+                " ORDER BY create_time DESC"));
 
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(*i);
-            }
-
-            trans.commit(); // 提交事务
-        } catch(std::exception &e) {
-            LOG_ERROR("获取申请信息失败 {}:{}", uid, e.what());
-        }
-        return res;
-    }
-    /* brief: 获取指定申请信息 */
-    std::shared_ptr<FriendApply> select(const std::string &uid, const std::string &pid) {
-        std::shared_ptr<FriendApply> res;
-        try {
-            odb::transaction trans(_db->begin()); // 获取事务对象，开启事务
-
-            using query  = odb::query<FriendApply>;
-            using result = odb::result<FriendApply>;
-
-            res.reset(_db->query_one<FriendApply>((query::user_id == uid) && (query::peer_id == pid)));
-
+            for(auto &row : r) res.push_back(row);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("通过申请者被申请者查询申请信息失败 {}-{}:{}", uid, pid, e.what());
+            LOG_ERROR("获取待处理申请列表失败 {}: {}", uid, e.what());
         }
         return res;
     }
+
+    /* brief: 通过事件 ID 取出申请详情 — 处理回调用 */
+    std::shared_ptr<FriendApply> select_by_event_id(const std::string &event_id) {
+        std::shared_ptr<FriendApply> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<FriendApply>;
+            res.reset(_db->query_one<FriendApply>(query::event_id == event_id));
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("通过 event_id 查询申请失败 {}: {}", event_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 取一对用户的最近一条申请（用于产品策略，如"X 分钟内不许再申请"） */
+    std::shared_ptr<FriendApply> select_latest(const std::string &uid, const std::string &pid) {
+        std::shared_ptr<FriendApply> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<FriendApply>;
+            using result = odb::result<FriendApply>;
+            result r(_db->query<FriendApply>(
+                (query::user_id == uid && query::peer_id == pid) +
+                " ORDER BY create_time DESC LIMIT 1"));
+            auto it = r.begin();
+            if(it != r.end()) res.reset(new FriendApply(*it));
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("查询最近申请失败 {}-{}: {}", uid, pid, e.what());
+        }
+        return res;
+    }
+
 private:
     std::shared_ptr<odb::core::database> _db;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/mysql_message.hpp
+++ b/code/server/common/mysql_message.hpp
@@ -5,121 +5,271 @@
 #include "message.hxx"
 #include "message-odb.hxx"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace chatnow
 {
 
+/**
+ * MessageTable
+ * ------------------------------------------------------------------
+ * message 表的 DAO 封装。
+ *
+ * 关键变化（对齐新 schema）：
+ *   - 查询路径从 message_id 全局排序改为 (session_id, seq_id) 范围扫
+ *     —— 走 uk_session_seq 唯一索引，免回表
+ *   - 新增基于 seq 的常用接口：recent_by_seq / range_by_seq / max_seq_of_session
+ *   - 新增 client_msg_id 幂等去重接口：select_by_client_msg
+ *   - 新增 mark_revoked / mark_deleted：状态机变更而非物理 erase
+ *   - insert / 重要写操作保留"外部事务感知"：服务层有 ODB 事务时复用
+ * ------------------------------------------------------------------
+ */
 class MessageTable
 {
 public:
     using ptr = std::shared_ptr<MessageTable>;
     MessageTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
-    ~MessageTable() {}
+    ~MessageTable() = default;
+
+    /* brief: 单条插入；外部已有事务则挂载，否则本地起一个 */
     bool insert(Message &msg) {
         try {
-            // 1. 检查外部是否已经开启了事务
             bool has_external_trans = odb::transaction::has_current();
-
-            // 2. 如果外部没有事务，我们才开启一个本地事务；否则只创建一个空的 holder
-            // std::unique_ptr 用于管理事务对象的生命周期
             std::unique_ptr<odb::transaction> local_trans;
-            
-            if (!has_external_trans) {
-                // 只有在没事务的时候，才由 DAO 开启
+            if(!has_external_trans) {
                 local_trans.reset(new odb::transaction(_db->begin()));
             }
-
-            // 3. 执行持久化操作 (ODB 会自动挂载到当前线程的活跃事务上)
             _db->persist(msg);
-
-            // 4. 只有当我们自己开启了事务，我们才负责提交
-            if (!has_external_trans) {
-                local_trans->commit();
-            }
-            
-            // 如果是外部事务，这里什么都不做，等外部 Service 去 commit
+            if(!has_external_trans) local_trans->commit();
         } catch(std::exception &e) {
-            LOG_ERROR("插入失败: {}", e.what());
-            throw; // 异常会向上传递，导致外部事务回滚
+            LOG_ERROR("插入消息失败: {}", e.what());
+            throw; // 让外部事务回滚
         }
         return true;
     }
-    bool remove(const std::string &ssid) {
+
+    /* brief: 批量插入（典型场景：转发多条 / 离线补偿）；事务感知 */
+    bool insert(std::vector<Message> &msgs) {
+        if(msgs.empty()) return true;
+        try {
+            bool has_external_trans = odb::transaction::has_current();
+            std::unique_ptr<odb::transaction> local_trans;
+            if(!has_external_trans) {
+                local_trans.reset(new odb::transaction(_db->begin()));
+            }
+            for(auto &m : msgs) _db->persist(m);
+            if(!has_external_trans) local_trans->commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量插入消息失败 count={}: {}", msgs.size(), e.what());
+            throw;
+        }
+        return true;
+    }
+
+    /* brief: 客户端断网重发幂等查找
+     *  - 走 uk_client_msg(user_id, client_msg_id) 唯一索引
+     *  - 命中即视为重复发送，直接复用旧 message 不再写库
+     */
+    std::shared_ptr<Message> select_by_client_msg(const std::string &user_id,
+                                                  const std::string &client_msg_id)
+    {
+        std::shared_ptr<Message> res;
+        if(client_msg_id.empty()) return res;
         try {
             odb::transaction trans(_db->begin());
-            typedef odb::query<Message> query;
-            typedef odb::result<Message> result;
-            _db->erase_query<Message>(query::session_id == ssid);
+            using query = odb::query<Message>;
+            res.reset(_db->query_one<Message>(
+                query::user_id == user_id && query::client_msg_id == client_msg_id));
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("删除会话所有消息失败 {} : {}", ssid, e.what());
+            LOG_ERROR("通过 client_msg_id 查询失败 {}-{}: {}", user_id, client_msg_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 全局消息 ID 查询（跨会话引用 / 转发回查） */
+    std::shared_ptr<Message> select_by_id(unsigned long message_id) {
+        std::shared_ptr<Message> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<Message>;
+            res.reset(_db->query_one<Message>(query::message_id == message_id));
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("按 message_id 查询失败 {}: {}", message_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 批量按 message_id 查（in_range，免拼字符串） */
+    std::vector<Message> select_by_ids(const std::vector<unsigned long> &ids) {
+        std::vector<Message> res;
+        if(ids.empty()) return res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<Message>;
+            using result = odb::result<Message>;
+            // 排序按 seq_id 升序，保证下游展示顺序确定
+            result r(_db->query<Message>(
+                query::message_id.in_range(ids.begin(), ids.end()) +
+                " ORDER BY seq_id ASC"));
+            for(auto &m : r) res.push_back(m);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量按 message_id 查询失败: {}", e.what());
+        }
+        return res;
+    }
+
+    /* brief: 取会话最近 N 条；按 seq_id 倒序后反转保证从旧到新展示
+     *  - 走 uk_session_seq 索引；无 ORDER BY create_time，避免索引外排序
+     */
+    std::vector<Message> recent_by_seq(const std::string &ssid, int count) {
+        std::vector<Message> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<Message>;
+            using result = odb::result<Message>;
+            std::stringstream cond;
+            cond << "session_id='" << ssid << "' "
+                 << "ORDER BY seq_id DESC LIMIT " << count;
+            result r(_db->query<Message>(cond.str()));
+            for(auto &m : r) res.push_back(m);
+            std::reverse(res.begin(), res.end());
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("取最近消息失败 {}-{}: {}", ssid, count, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 取会话内 [start_seq, end_seq] 范围消息（按 seq 升序）
+     *  - 客户端按 seq 增量同步的核心查询路径
+     */
+    std::vector<Message> range_by_seq(const std::string &ssid,
+                                      unsigned long start_seq,
+                                      unsigned long end_seq)
+    {
+        std::vector<Message> res;
+        if(start_seq > end_seq) return res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<Message>;
+            using result = odb::result<Message>;
+            result r(_db->query<Message>(
+                (query::session_id == ssid &&
+                 query::seq_id >= start_seq &&
+                 query::seq_id <= end_seq) +
+                " ORDER BY seq_id ASC"));
+            for(auto &m : r) res.push_back(m);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("按 seq 范围查询失败 {} [{}-{}]: {}", ssid, start_seq, end_seq, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 取会话当前最大 seq（DB 层，最终一致；强一致用 Redis） */
+    unsigned long max_seq_of_session(const std::string &ssid) {
+        unsigned long max_seq = 0;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<Message>;
+            using result = odb::result<Message>;
+            result r(_db->query<Message>(
+                (query::session_id == ssid) + " ORDER BY seq_id DESC LIMIT 1"));
+            auto it = r.begin();
+            if(it != r.end()) max_seq = it->seq_id();
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("取会话最大 seq 失败 {}: {}", ssid, e.what());
+        }
+        return max_seq;
+    }
+
+    /* brief: 兼容旧接口 — 按时间范围（保留以平滑过渡，建议改用 range_by_seq） */
+    std::vector<Message> range(const std::string &ssid,
+                               boost::posix_time::ptime stime,
+                               boost::posix_time::ptime etime)
+    {
+        std::vector<Message> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<Message>;
+            using result = odb::result<Message>;
+            result r(_db->query<Message>(
+                (query::session_id == ssid &&
+                 query::create_time >= stime &&
+                 query::create_time <= etime) +
+                " ORDER BY seq_id ASC"));
+            for(auto &m : r) res.push_back(m);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("按时间范围查询失败 {}: {}", ssid, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 撤回消息（改状态而非删行） */
+    bool mark_revoked(unsigned long message_id, const std::string &operator_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<Message>;
+            std::shared_ptr<Message> m(_db->query_one<Message>(query::message_id == message_id));
+            if(!m) {
+                trans.commit();
+                return false;
+            }
+            m->status(MessageStatus::REVOKED);
+            m->revoke_time(boost::posix_time::microsec_clock::universal_time());
+            m->revoke_by(operator_id);
+            _db->update(*m);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("撤回消息失败 {}: {}", message_id, e.what());
             return false;
         }
         return true;
     }
-    std::vector<Message> recent(const std::string &ssid, int count) {
-        std::vector<Message> res;
+
+    /* brief: 软删除（运营 / 风控）— 保留行做审计 */
+    bool mark_deleted(unsigned long message_id) {
         try {
             odb::transaction trans(_db->begin());
-            typedef odb::query<Message> query;
-            typedef odb::result<Message> result;
-            // 本次查询以ssid作为过滤条件，然后进行以时间字段进行逆序，通过limit
-            // session_id='xx' order by create_time desc limit cont;
-            std::stringstream cond;
-            cond << "session_id='" << ssid << "' ";
-            cond << "order by create_time desc limit " << count;
-            result r(_db->query<Message>(cond.str()));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(*i);
+            using query = odb::query<Message>;
+            std::shared_ptr<Message> m(_db->query_one<Message>(query::message_id == message_id));
+            if(!m) {
+                trans.commit();
+                return false;
             }
-            std::reverse(res.begin(), res.end());
+            m->status(MessageStatus::DELETED);
+            _db->update(*m);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("获取最近消息失败 {}-{}-{}", ssid, count, e.what());
+            LOG_ERROR("软删除消息失败 {}: {}", message_id, e.what());
+            return false;
         }
-        return res;
+        return true;
     }
-    std::vector<Message> range(const std::string &ssid, boost::posix_time::ptime stime, boost::posix_time::ptime etime) {
-        std::vector<Message> res;
+
+    /* brief: 物理删除会话所有消息（仅在群解散且需清理冷数据时使用） */
+    bool remove_by_session(const std::string &ssid) {
         try {
             odb::transaction trans(_db->begin());
-            typedef odb::query<Message> query;
-            typedef odb::result<Message> result;
-            // 获取指定会话指定时间段的信息
-            result r(_db->query<Message>(query::session_id == ssid && query::create_time >= stime && query::create_time <= etime));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(*i);
-            }
+            using query = odb::query<Message>;
+            _db->erase_query<Message>(query::session_id == ssid);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("获取区间消息失败 {}-{}:{}-{}", ssid, boost::posix_time::to_simple_string(stime), boost::posix_time::to_simple_string(etime), e.what());
+            LOG_ERROR("清理会话消息失败 {}: {}", ssid, e.what());
+            return false;
         }
-        return res;
+        return true;
     }
-    // 在 MessageTable 类中增加
-    std::vector<Message> select_by_ids(const std::vector<unsigned long>& ids) {
-        std::vector<Message> res;
-        if (ids.empty()) return res;
-        
-        try {
-            odb::transaction trans(_db->begin());
-            typedef odb::query<Message> query;
-            typedef odb::result<Message> result;
-            
-            // 使用 IN 语法：WHERE message_id IN (1, 2, 3...)
-            result r(_db->query<Message>(query::message_id.in_range(ids.begin(), ids.end()) + 
-                                        " ORDER BY create_time ASC")); 
-            
-            for(auto& m : r) {
-                res.push_back(m);
-            }
-            trans.commit();
-        } catch(std::exception& e) {
-            LOG_ERROR("批量主键查询消息失败: {}", e.what());
-        }
-        return res;
-    }
+
 private:
     std::shared_ptr<odb::core::database> _db;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/mysql_message_attachment.hpp
+++ b/code/server/common/mysql_message_attachment.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "logger.hpp"
+#include "mysql.hpp"
+#include "message_attachment.hxx"
+#include "message_attachment-odb.hxx"
+#include <odb/database.hxx>
+#include <odb/mysql/database.hxx>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace chatnow
+{
+
+/**
+ * MessageAttachmentTable
+ * ------------------------------------------------------------------
+ * message_attachment 表的 DAO 封装（多附件场景）。
+ *
+ * 写入约定（与 message 主表关系）：
+ *   - 多附件场景（多图、视频带封面等）只写本表，message.file_id 留空
+ *   - 单附件场景仍可双写以保持兼容；读取一律以本表 count > 0 为准
+ *
+ * 典型路径：
+ *   - 上传完成后批量 insert（一条 message 对应 N 行）
+ *   - 客户端拉历史消息时按 message_id 取附件清单
+ * ------------------------------------------------------------------
+ */
+class MessageAttachmentTable
+{
+public:
+    using ptr = std::shared_ptr<MessageAttachmentTable>;
+    MessageAttachmentTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
+
+    /* brief: 单条插入；事务感知 — 与 message 主表是同一写事务 */
+    bool insert(MessageAttachment &att) {
+        try {
+            if(att.create_time().is_not_a_date_time()) {
+                att.create_time(boost::posix_time::microsec_clock::universal_time());
+            }
+            bool has_external_trans = odb::transaction::has_current();
+            std::unique_ptr<odb::transaction> local_trans;
+            if(!has_external_trans) {
+                local_trans.reset(new odb::transaction(_db->begin()));
+            }
+            _db->persist(att);
+            if(!has_external_trans) local_trans->commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("插入附件失败 mid={}: {}", att.message_id(), e.what());
+            throw;
+        }
+        return true;
+    }
+
+    /* brief: 批量插入（多图发送主路径） */
+    bool insert(std::vector<MessageAttachment> &atts) {
+        if(atts.empty()) return true;
+        try {
+            auto now = boost::posix_time::microsec_clock::universal_time();
+            bool has_external_trans = odb::transaction::has_current();
+            std::unique_ptr<odb::transaction> local_trans;
+            if(!has_external_trans) {
+                local_trans.reset(new odb::transaction(_db->begin()));
+            }
+            for(auto &att : atts) {
+                if(att.create_time().is_not_a_date_time()) att.create_time(now);
+                _db->persist(att);
+            }
+            if(!has_external_trans) local_trans->commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量插入附件失败 count={}: {}", atts.size(), e.what());
+            throw;
+        }
+        return true;
+    }
+
+    /* brief: 取一条消息的附件清单（按 order_idx 升序） */
+    std::vector<MessageAttachment> list_of(unsigned long message_id) {
+        std::vector<MessageAttachment> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<MessageAttachment>;
+            using result = odb::result<MessageAttachment>;
+            result r(_db->query<MessageAttachment>(
+                (query::message_id == message_id) + " ORDER BY order_idx ASC"));
+            for(auto &att : r) res.push_back(att);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("查询附件清单失败 mid={}: {}", message_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 批量按 message_id 取附件清单 — 拉历史消息时一次性聚合
+     *  - 返回 map<message_id, attachments>，调用方按 mid 重组
+     */
+    std::vector<MessageAttachment> list_of_messages(const std::vector<unsigned long> &mids) {
+        std::vector<MessageAttachment> res;
+        if(mids.empty()) return res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<MessageAttachment>;
+            using result = odb::result<MessageAttachment>;
+            result r(_db->query<MessageAttachment>(
+                query::message_id.in_range(mids.begin(), mids.end()) +
+                " ORDER BY message_id ASC, order_idx ASC"));
+            for(auto &att : r) res.push_back(att);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量查询附件失败: {}", e.what());
+        }
+        return res;
+    }
+
+    /* brief: 删除消息的所有附件（消息撤回 / 风控删除时联动） */
+    bool remove_by_message(unsigned long message_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<MessageAttachment>;
+            _db->erase_query<MessageAttachment>(query::message_id == message_id);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("删除附件失败 mid={}: {}", message_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<odb::core::database> _db;
+};
+
+} // namespace chatnow

--- a/code/server/common/mysql_message_mention.hpp
+++ b/code/server/common/mysql_message_mention.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "logger.hpp"
+#include "mysql.hpp"
+#include "message_mention.hxx"
+#include "message_mention-odb.hxx"
+#include <odb/database.hxx>
+#include <odb/mysql/database.hxx>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace chatnow
+{
+
+/**
+ * MessageMentionTable
+ * ------------------------------------------------------------------
+ * message_mention 表的 DAO 封装。
+ *
+ * 设计要点：
+ *   - 用约定的 user_id="*" 表示 @全体，避免群人数膨胀写放大
+ *   - 客户端拉取被 @ 的消息时同时匹配自己的 user_id 与 "*"
+ *   - uk_msg_user 唯一约束让 ack 写入幂等
+ *
+ * 索引使用：
+ *   - uk_msg_user(message_id, user_id) — 写时去重
+ *   - idx_user_msg(user_id, message_id) — "我被 @ 的所有消息"
+ * ------------------------------------------------------------------
+ */
+class MessageMentionTable
+{
+public:
+    using ptr = std::shared_ptr<MessageMentionTable>;
+    MessageMentionTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
+
+    /* brief: 批量写入 — 消息发送时一次写入所有被 @ 用户行；事务感知 */
+    bool insert(unsigned long message_id, const std::vector<std::string> &user_ids) {
+        if(user_ids.empty()) return true;
+        try {
+            bool has_external_trans = odb::transaction::has_current();
+            std::unique_ptr<odb::transaction> local_trans;
+            if(!has_external_trans) {
+                local_trans.reset(new odb::transaction(_db->begin()));
+            }
+            for(const auto &uid : user_ids) {
+                MessageMention mm(message_id, uid);
+                try {
+                    _db->persist(mm);
+                } catch(odb::exception &) {
+                    // 唯一约束冲突视为幂等，跳过
+                }
+            }
+            if(!has_external_trans) local_trans->commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量插入 @ 提及失败 mid={}: {}", message_id, e.what());
+            throw;
+        }
+        return true;
+    }
+
+    /* brief: 标记 @ 全体（单行 user_id="*"） */
+    bool insert_at_all(unsigned long message_id) {
+        return insert(message_id, std::vector<std::string>{"*"});
+    }
+
+    /* brief: 取一条消息的 @ 清单 */
+    std::vector<std::string> list_of(unsigned long message_id) {
+        std::vector<std::string> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<MessageMention>;
+            using result = odb::result<MessageMention>;
+            result r(_db->query<MessageMention>(query::message_id == message_id));
+            for(auto &m : r) res.push_back(m.user_id());
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("查询 @ 清单失败 mid={}: {}", message_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 我是否被 @（包含 "*" 全体）*/
+    bool is_mentioned(unsigned long message_id, const std::string &user_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<MessageMention>;
+            std::shared_ptr<MessageMention> r(_db->query_one<MessageMention>(
+                query::message_id == message_id &&
+                (query::user_id == user_id || query::user_id == "*")));
+            trans.commit();
+            return r != nullptr;
+        } catch(std::exception &e) {
+            LOG_ERROR("查询是否被 @ 失败 mid={} uid={}: {}", message_id, user_id, e.what());
+            return false;
+        }
+    }
+
+    /* brief: "我被 @ 的所有消息 ID" — 走 idx_user_msg 索引
+     *  - 同时匹配自己 ID 与 "*"，按 message_id 倒序分页（消息 ID 雪花趋势递增）
+     */
+    std::vector<unsigned long> list_my_mentions(const std::string &user_id, size_t limit = 100) {
+        std::vector<unsigned long> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<MessageMention>;
+            using result = odb::result<MessageMention>;
+            result r(_db->query<MessageMention>(
+                (query::user_id == user_id || query::user_id == "*") +
+                " ORDER BY message_id DESC LIMIT " + std::to_string(limit)));
+            for(auto &m : r) res.push_back(m.message_id());
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("查询我被 @ 列表失败 uid={}: {}", user_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 撤回 / 删除消息时联动清理 */
+    bool remove_by_message(unsigned long message_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<MessageMention>;
+            _db->erase_query<MessageMention>(query::message_id == message_id);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("删除 @ 记录失败 mid={}: {}", message_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<odb::core::database> _db;
+};
+
+} // namespace chatnow

--- a/code/server/common/mysql_message_read.hpp
+++ b/code/server/common/mysql_message_read.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+#include "logger.hpp"
+#include "mysql.hpp"
+#include "message_read.hxx"
+#include "message_read-odb.hxx"
+#include <odb/database.hxx>
+#include <odb/mysql/database.hxx>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace chatnow
+{
+
+/**
+ * MessageReadTable
+ * ------------------------------------------------------------------
+ * message_read 表的 DAO 封装（群消息已读回执）。
+ *
+ * 注意写入路径：
+ *   - 高 QPS 写入应走 Redis 暂存（key: read:{message_id}）+ 后台批量异步刷库
+ *   - 本 DAO 是落库接口；ack() 单条写仅用于低频/调试场景
+ *   - 大群消息发出 24h 后停止收集 ack（产品策略）
+ *
+ * 索引使用：
+ *   - uk_msg_user (message_id, user_id) — 唯一约束兜底防重复
+ *   - idx_msg_time (message_id, read_time) — 已读列表分页（按时间倒序）
+ * ------------------------------------------------------------------
+ */
+class MessageReadTable
+{
+public:
+    using ptr = std::shared_ptr<MessageReadTable>;
+    MessageReadTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
+
+    /* brief: 单条 ack（重复写依赖 uk_msg_user 唯一约束） */
+    bool ack(unsigned long message_id, const std::string &user_id) {
+        try {
+            MessageRead mr(message_id, user_id, boost::posix_time::microsec_clock::universal_time());
+            odb::transaction trans(_db->begin());
+            _db->persist(mr);
+            trans.commit();
+        } catch(std::exception &e) {
+            // 唯一冲突视为幂等成功，不上报错误
+            LOG_DEBUG("已读 ack 写入 {}/{}: {}", message_id, user_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 批量 ack — 后台批处理刷库主路径 */
+    bool ack_batch(std::vector<MessageRead> &acks) {
+        if(acks.empty()) return true;
+        try {
+            odb::transaction trans(_db->begin());
+            for(auto &mr : acks) {
+                try {
+                    _db->persist(mr);
+                } catch(odb::exception &) {
+                    // 单行重复忽略，不让整批回滚
+                }
+            }
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量已读 ack 失败 count={}: {}", acks.size(), e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 取一条消息的"已读名单"（按 read_time 倒序分页） */
+    std::vector<MessageRead> readers_of(unsigned long message_id, size_t limit = 200) {
+        std::vector<MessageRead> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<MessageRead>;
+            using result = odb::result<MessageRead>;
+            result r(_db->query<MessageRead>(
+                (query::message_id == message_id) +
+                " ORDER BY read_time DESC LIMIT " + std::to_string(limit)));
+            for(auto &row : r) res.push_back(row);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("查询已读列表失败 mid={}: {}", message_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 已读人数（角标"已读 X 人"显示用） */
+    int reader_count(unsigned long message_id) {
+        int count = 0;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<MessageRead>;
+            using result = odb::result<MessageRead>;
+            result r(_db->query<MessageRead>(query::message_id == message_id));
+            for(auto it = r.begin(); it != r.end(); ++it) ++count;
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("查询已读数失败 mid={}: {}", message_id, e.what());
+        }
+        return count;
+    }
+
+    /* brief: 我是否已读某条消息 */
+    bool has_read(unsigned long message_id, const std::string &user_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<MessageRead>;
+            std::shared_ptr<MessageRead> r(_db->query_one<MessageRead>(
+                query::message_id == message_id && query::user_id == user_id));
+            trans.commit();
+            return r != nullptr;
+        } catch(std::exception &e) {
+            LOG_ERROR("查询已读状态失败 mid={} uid={}: {}", message_id, user_id, e.what());
+            return false;
+        }
+    }
+
+private:
+    std::shared_ptr<odb::core::database> _db;
+};
+
+} // namespace chatnow

--- a/code/server/common/mysql_relation.hpp
+++ b/code/server/common/mysql_relation.hpp
@@ -7,19 +7,40 @@
 #include <odb/database.hxx>
 #include <odb/mysql/database.hxx>
 
-namespace chatnow 
+#include <vector>
+#include <string>
+
+namespace chatnow
 {
 
+/**
+ * RelationTable
+ * ------------------------------------------------------------------
+ * relation 表（双向冗余）的 DAO 封装。
+ *
+ * 关键变化：
+ *   - 不再物理删除好友：remove() 改为软删除，置 status=DELETED 保留行，
+ *     便于风控审计与"加回好友"识别历史关系
+ *   - 新增字段相关写入接口：备注 / 分组 / 星标 / 拉黑
+ *   - friends() 仅返回 status=NORMAL 的好友，过滤掉拉黑/已删除的对端
+ *   - 任何状态变更都自动维护 update_time，客户端按 update_time 增量同步
+ * ------------------------------------------------------------------
+ */
 class RelationTable
 {
 public:
     using ptr = std::shared_ptr<RelationTable>;
     RelationTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
-    /* brief: 新增关系信息 */
+
+    /* brief: 双向新增好友关系（同意申请时调用） */
     bool insert(const std::string &uid, const std::string &pid) {
         try {
+            auto now = boost::posix_time::microsec_clock::universal_time();
             Relation r1(uid, pid);
             Relation r2(pid, uid);
+            r1.create_time(now); r1.update_time(now);
+            r2.create_time(now); r2.update_time(now);
+
             odb::transaction trans(_db->begin());
             _db->persist(r1);
             _db->persist(r2);
@@ -30,16 +51,27 @@ public:
         }
         return true;
     }
-    /* brief: 移除关系信息 */
+
+    /* brief: 软删除好友关系（双向置 DELETED，保留历史行）
+     *  - 不物理 erase，避免破坏申请审计与"加回好友"识别旧关系
+     */
     bool remove(const std::string &uid, const std::string &pid) {
         try {
+            auto now = boost::posix_time::microsec_clock::universal_time();
             odb::transaction trans(_db->begin());
-            
-            typedef odb::query<Relation> query;
-            typedef odb::result<Relation> result;
-            _db->erase_query<Relation>(query::user_id == uid && query::peer_id == pid);
-            _db->erase_query<Relation>(query::user_id == pid && query::peer_id == uid);
+            using query = odb::query<Relation>;
 
+            auto soft_delete = [&](const std::string &a, const std::string &b) {
+                std::shared_ptr<Relation> r(_db->query_one<Relation>(
+                    query::user_id == a && query::peer_id == b));
+                if(r) {
+                    r->status(RelationStatus::DELETED);
+                    r->update_time(now);
+                    _db->update(*r);
+                }
+            };
+            soft_delete(uid, pid);
+            soft_delete(pid, uid);
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("删除用户好友关系失败 {}-{}: {}", uid, pid, e.what());
@@ -47,46 +79,117 @@ public:
         }
         return true;
     }
-    /* brief: 判断关系是否存在 */
+
+    /* brief: 是否互为好友（双向都 NORMAL 才算）
+     *  - 拉黑 / 删除场景下 exists 返回 false，避免给对方发消息成功
+     */
     bool exists(const std::string &uid, const std::string &pid) {
-        typedef odb::query<Relation> query;
-        typedef odb::result<Relation> result;
-        result r;
-        bool flag = false;
         try {
             odb::transaction trans(_db->begin());
-            
-            r = _db->query<Relation>(query::user_id == uid && query::peer_id == pid);
-            flag = !r.empty();
-
+            using query = odb::query<Relation>;
+            std::shared_ptr<Relation> a(_db->query_one<Relation>(
+                query::user_id == uid && query::peer_id == pid &&
+                query::status == RelationStatus::NORMAL));
+            std::shared_ptr<Relation> b(_db->query_one<Relation>(
+                query::user_id == pid && query::peer_id == uid &&
+                query::status == RelationStatus::NORMAL));
             trans.commit();
+            return a && b;
         } catch(std::exception &e) {
             LOG_ERROR("查询用户好友关系失败 {}-{}: {}", uid, pid, e.what());
             return false;
         }
-        return flag;
     }
-    /* brief: 获取指定用户的好友ID */
+
+    /* brief: 获取我的所有正常好友 ID（status=NORMAL）
+     *  - 拉黑/已删除不返回；走 uk_user_peer 前缀扫描，不需要回表
+     */
     std::vector<std::string> friends(const std::string &uid) {
         std::vector<std::string> res;
         try {
             odb::transaction trans(_db->begin());
-            
-            typedef odb::query<Relation> query;
-            typedef odb::result<Relation> result;
-            result r(_db->query<Relation>(query::user_id == uid));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(i->peer_id());
-            }
- 
+            using query  = odb::query<Relation>;
+            using result = odb::result<Relation>;
+            result r(_db->query<Relation>(
+                query::user_id == uid && query::status == RelationStatus::NORMAL));
+            for(auto &row : r) res.push_back(row.peer_id());
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("通过用户ID: {} 获取好友ID失败: {}", uid, e.what());
         }
         return res;
     }
+
+    /* brief: 获取关系详情（含备注/分组/状态等） */
+    std::shared_ptr<Relation> select(const std::string &uid, const std::string &pid) {
+        std::shared_ptr<Relation> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<Relation>;
+            res.reset(_db->query_one<Relation>(
+                query::user_id == uid && query::peer_id == pid));
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("查询好友关系详情失败 {}-{}: {}", uid, pid, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 修改对对端的备注 / 分组 / 星标 — 仅影响"我"这一行 */
+    bool update_meta(const std::string &uid, const std::string &pid,
+                     const std::string &remark,
+                     const std::string &group_name,
+                     bool starred)
+    {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<Relation>;
+            std::shared_ptr<Relation> r(_db->query_one<Relation>(
+                query::user_id == uid && query::peer_id == pid));
+            if(!r) {
+                trans.commit();
+                return false;
+            }
+            r->remark(remark);
+            r->group_name(group_name);
+            r->starred(starred);
+            r->update_time(boost::posix_time::microsec_clock::universal_time());
+            _db->update(*r);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新好友备注失败 {}-{}: {}", uid, pid, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 拉黑 / 解除拉黑 — 仅影响"我"这一行
+     *  - 与 remove() 区别：BLOCKED 仍保留好友关系，对端可见仍是好友；
+     *    DELETED 则彻底视为不是好友
+     */
+    bool set_status(const std::string &uid, const std::string &pid, RelationStatus status) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<Relation>;
+            std::shared_ptr<Relation> r(_db->query_one<Relation>(
+                query::user_id == uid && query::peer_id == pid));
+            if(!r) {
+                trans.commit();
+                return false;
+            }
+            r->status(status);
+            r->update_time(boost::posix_time::microsec_clock::universal_time());
+            _db->update(*r);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("修改好友关系状态失败 {}-{}: {}", uid, pid, e.what());
+            return false;
+        }
+        return true;
+    }
+
 private:
     std::shared_ptr<odb::core::database> _db;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/mysql_user.hpp
+++ b/code/server/common/mysql_user.hpp
@@ -7,22 +7,41 @@
 #include <odb/database.hxx>
 #include <odb/mysql/database.hxx>
 
+#include <memory>
+#include <vector>
+#include <string>
 
 namespace chatnow
 {
 
+/**
+ * UserTable
+ * ------------------------------------------------------------------
+ * user 表的 DAO 封装。新版 schema 引入 phone / status / 登录信息 / update_time，
+ * 因此本类对外 API 增加：
+ *   - select_by_phone：手机号登录入口
+ *   - touch_login：登录成功后写入 last_login_time / last_login_ip
+ *   - set_status：账号状态变更（封禁 / 注销）
+ *   - select_multi_users：保留批量查询，改用 in_range 替代字符串拼 SQL（防注入 + 类型安全）
+ * 所有 update/insert 都自动维护 update_time。
+ * ------------------------------------------------------------------
+ */
 class UserTable
 {
 public:
     using ptr = std::shared_ptr<UserTable>;
-    
+
     UserTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
+
+    /* brief: 新增用户；自动填 register_time 与 update_time */
     bool insert(std::shared_ptr<User> &user) {
         try {
-            //获取事务对象，开启事务
+            auto now = boost::posix_time::microsec_clock::universal_time();
+            user->register_time(now);
+            user->update_time(now);
+
             odb::transaction trans(_db->begin());
             _db->persist(*user);
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("新增用户失败: {}-{}", user->nickname(), e.what());
@@ -30,12 +49,14 @@ public:
         }
         return true;
     }
+
+    /* brief: 通用更新；自动刷新 update_time，便于客户端"我的资料"增量同步 */
     bool update(const std::shared_ptr<User> &user) {
         try {
-            //获取事务对象，开启事务
+            user->update_time(boost::posix_time::microsec_clock::universal_time());
+
             odb::transaction trans(_db->begin());
             _db->update(*user);
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("更新用户失败: {}-{}", user->nickname(), e.what());
@@ -43,84 +64,126 @@ public:
         }
         return true;
     }
+
+    /* brief: 按昵称查询（昵称不再 unique，可能多匹配，调用方自行处理重名） */
     std::shared_ptr<User> select_by_nickname(const std::string &nickname) {
         std::shared_ptr<User> res;
         try {
-            //获取事务对象，开启事务
             odb::transaction trans(_db->begin());
-            typedef odb::query<User> query;
-            typedef odb::result<User> result;
+            using query = odb::query<User>;
             res.reset(_db->query_one<User>(query::nickname == nickname));
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("通过昵称查询用户失败: {}-{}", nickname, e.what());
         }
         return res;
     }
+
+    /* brief: 按邮箱查询（邮箱唯一） */
     std::shared_ptr<User> select_by_mail(const std::string &mail) {
         std::shared_ptr<User> res;
         try {
-            //获取事务对象，开启事务
             odb::transaction trans(_db->begin());
-            typedef odb::query<User> query;
-            typedef odb::result<User> result;
+            using query = odb::query<User>;
             res.reset(_db->query_one<User>(query::mail == mail));
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("通过邮箱查询用户失败: {}-{}", mail, e.what());
         }
         return res;
     }
+
+    /* brief: 按手机号查询（手机号唯一）— 新版 schema 新增登录入口 */
+    std::shared_ptr<User> select_by_phone(const std::string &phone) {
+        std::shared_ptr<User> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<User>;
+            res.reset(_db->query_one<User>(query::phone == phone));
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("通过手机号查询用户失败: {}-{}", phone, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 按业务用户 ID 查询 */
     std::shared_ptr<User> select_by_id(const std::string &user_id) {
         std::shared_ptr<User> res;
         try {
-            //获取事务对象，开启事务
             odb::transaction trans(_db->begin());
-            typedef odb::query<User> query;
-            typedef odb::result<User> result;
+            using query = odb::query<User>;
             res.reset(_db->query_one<User>(query::user_id == user_id));
-            //提交事务
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("通过用户ID查询用户失败: {}-{}", user_id, e.what());
         }
         return res;
     }
-    std::vector<User> select_multi_users(const std::vector<std::string> &id_list) {
-        // selcet * from user where id in ('id1', '1d2', ...)
-        std::vector<User> res;
-        if(id_list.empty()) {
-            return res;
-        }
-        try {
-            //获取事务对象，开启事务
-            odb::transaction trans(_db->begin());
-            typedef odb::query<User> query;
-            typedef odb::result<User> result;
-            std::stringstream ss;
-            ss << "user_id in (";
-            for(const auto &id : id_list) {
-                ss << "'"<< id << "',";
-            }
-            std::string condition = ss.str();
-            condition.pop_back();
-            condition += ")";
 
-            result r(_db->query<User>(condition));
-            for(result::iterator i(r.begin()); i != r.end(); ++i) {
-                res.push_back(*i);
-            }
-            //提交事务
+    /* brief: 批量查询；in_range 替代旧的字符串拼接，防 SQL 注入 */
+    std::vector<User> select_multi_users(const std::vector<std::string> &id_list) {
+        std::vector<User> res;
+        if(id_list.empty()) return res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<User>;
+            using result = odb::result<User>;
+            result r(_db->query<User>(query::user_id.in_range(id_list.begin(), id_list.end())));
+            for(auto &u : r) res.push_back(u);
             trans.commit();
         } catch(std::exception &e) {
             LOG_ERROR("通过多个用户ID查询多个用户失败: {}", e.what());
         }
         return res;
     }
+
+    /* brief: 登录成功回写：last_login_time / last_login_ip / update_time */
+    bool touch_login(const std::string &user_id, const std::string &login_ip) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<User>;
+            std::shared_ptr<User> u(_db->query_one<User>(query::user_id == user_id));
+            if(!u) {
+                trans.commit();
+                return false;
+            }
+            auto now = boost::posix_time::microsec_clock::universal_time();
+            u->last_login_time(now);
+            if(!login_ip.empty()) u->last_login_ip(login_ip);
+            u->update_time(now);
+            _db->update(*u);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新登录信息失败 {}: {}", user_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 修改账号状态（封禁 / 注销）— 风控用 */
+    bool set_status(const std::string &user_id, UserStatus status) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<User>;
+            std::shared_ptr<User> u(_db->query_one<User>(query::user_id == user_id));
+            if(!u) {
+                trans.commit();
+                return false;
+            }
+            u->status(status);
+            u->update_time(boost::posix_time::microsec_clock::universal_time());
+            _db->update(*u);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("修改账号状态失败 {}: {}", user_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
 private:
     std::shared_ptr<odb::core::database> _db;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/mysql_user_device.hpp
+++ b/code/server/common/mysql_user_device.hpp
@@ -1,0 +1,221 @@
+#pragma once
+
+#include "logger.hpp"
+#include "mysql.hpp"
+#include "user_device.hxx"
+#include "user_device-odb.hxx"
+#include <odb/database.hxx>
+#include <odb/mysql/database.hxx>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace chatnow
+{
+
+/**
+ * UserDeviceTable
+ * ------------------------------------------------------------------
+ * user_device 表的 DAO 封装（多端登录 / 推送 / 风控）。
+ *
+ * 典型使用场景：
+ *   - 登录：upsert_login() — 同一用户同一设备只一行（uk_user_device 唯一）
+ *   - 心跳：touch_active() — 仅写 last_active_time 与 online_status
+ *   - 推送：list_active_for_push() — 取该用户所有在线设备的 push_token
+ *   - 风控：set_offline_by_session() — 强制下线指定 session
+ *
+ * 设计要点：
+ *   - last_active_time 不索引（30s 心跳频率写抖动太大），找掉线设备走批处理扫表
+ *   - online_status 实时态在 Redis 维护；DB 落库为 last-known 快照
+ *   - push_token 唯一约束防账号切换残留：旧 row 的 token 必须先清空再写新 row
+ * ------------------------------------------------------------------
+ */
+class UserDeviceTable
+{
+public:
+    using ptr = std::shared_ptr<UserDeviceTable>;
+    UserDeviceTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
+
+    /* brief: 登录写入（首次登录 = persist；已有 = update） */
+    bool upsert_login(UserDevice &dev) {
+        try {
+            auto now = boost::posix_time::microsec_clock::universal_time();
+            dev.login_time(now);
+            dev.last_active_time(now);
+            dev.update_time(now);
+            dev.online_status(OnlineStatus::ONLINE);
+
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserDevice>;
+            std::shared_ptr<UserDevice> existing(_db->query_one<UserDevice>(
+                query::user_id == dev.user_id() && query::device_id == dev.device_id()));
+
+            if(existing) {
+                existing->device_type(dev.device_type());
+                existing->device_name(dev.device_name());
+                existing->app_version(dev.app_version());
+                existing->os_version(dev.os_version());
+                existing->login_session_id(dev.login_session_id());
+                existing->push_token(dev.push_token());
+                existing->login_ip(dev.login_ip());
+                existing->online_status(OnlineStatus::ONLINE);
+                existing->last_active_time(now);
+                existing->login_time(now);
+                existing->expire_time(dev.expire_time());
+                existing->update_time(now);
+                _db->update(*existing);
+            } else {
+                _db->persist(dev);
+            }
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("登录写入设备失败 {}-{}: {}", dev.user_id(), dev.device_id(), e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 心跳 — 仅刷活跃时间，不动其他字段（轻量、避免 update_time 干扰） */
+    bool touch_active(const std::string &session_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserDevice>;
+            std::shared_ptr<UserDevice> dev(_db->query_one<UserDevice>(
+                query::login_session_id == session_id));
+            if(!dev) {
+                trans.commit();
+                return false;
+            }
+            dev->last_active_time(boost::posix_time::microsec_clock::universal_time());
+            dev->online_status(OnlineStatus::ONLINE);
+            _db->update(*dev);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新设备心跳失败 sid={}: {}", session_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 通过 session_id 查设备（与 Redis Session 配合） */
+    std::shared_ptr<UserDevice> select_by_session(const std::string &session_id) {
+        std::shared_ptr<UserDevice> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserDevice>;
+            res.reset(_db->query_one<UserDevice>(query::login_session_id == session_id));
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("通过 session_id 查设备失败 {}: {}", session_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 取用户所有"在线"设备（含 ONLINE/AWAY/BUSY 等非离线状态）
+     *  - 推送下发的核心入口；调用方再各自拿 push_token 投递
+     */
+    std::vector<UserDevice> list_active(const std::string &user_id) {
+        std::vector<UserDevice> res;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<UserDevice>;
+            using result = odb::result<UserDevice>;
+            result r(_db->query<UserDevice>(
+                query::user_id == user_id && query::online_status != OnlineStatus::OFFLINE));
+            for(auto &dev : r) res.push_back(dev);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("取用户在线设备失败 {}: {}", user_id, e.what());
+        }
+        return res;
+    }
+
+    /* brief: 强制下线某个 session（管理员踢人 / 互斥登录） */
+    bool set_offline_by_session(const std::string &session_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserDevice>;
+            std::shared_ptr<UserDevice> dev(_db->query_one<UserDevice>(
+                query::login_session_id == session_id));
+            if(!dev) {
+                trans.commit();
+                return false;
+            }
+            dev->online_status(OnlineStatus::OFFLINE);
+            dev->update_time(boost::posix_time::microsec_clock::universal_time());
+            _db->update(*dev);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("强制下线设备失败 {}: {}", session_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 一个用户的所有设备全部下线（账号被封禁 / 用户主动注销）*/
+    bool set_offline_all(const std::string &user_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserDevice>;
+            using result = odb::result<UserDevice>;
+            result r(_db->query<UserDevice>(query::user_id == user_id));
+            auto now = boost::posix_time::microsec_clock::universal_time();
+            for(auto &dev : r) {
+                if(dev.online_status() != OnlineStatus::OFFLINE) {
+                    UserDevice copy = dev;
+                    copy.online_status(OnlineStatus::OFFLINE);
+                    copy.update_time(now);
+                    _db->update(copy);
+                }
+            }
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("批量下线设备失败 {}: {}", user_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 移除设备（用户解绑 / 卸载 App） */
+    bool remove(const std::string &user_id, const std::string &device_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserDevice>;
+            _db->erase_query<UserDevice>(
+                query::user_id == user_id && query::device_id == device_id);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("移除设备失败 {}-{}: {}", user_id, device_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: push_token 全局迁移 — 旧用户 row 清空 token，便于 uk_push_token 让出 */
+    bool clear_push_token_globally(const std::string &push_token) {
+        if(push_token.empty()) return true;
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserDevice>;
+            using result = odb::result<UserDevice>;
+            result r(_db->query<UserDevice>(query::push_token == push_token));
+            for(auto &dev : r) {
+                UserDevice copy = dev;
+                copy.push_token(""); // 让出唯一约束
+                copy.update_time(boost::posix_time::microsec_clock::universal_time());
+                _db->update(copy);
+            }
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("清理 push_token 失败: {}", e.what());
+            return false;
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<odb::core::database> _db;
+};
+
+} // namespace chatnow

--- a/code/server/common/mysql_user_timeline.hpp
+++ b/code/server/common/mysql_user_timeline.hpp
@@ -7,323 +7,303 @@
 #include <odb/database.hxx>
 #include <odb/mysql/database.hxx>
 
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace chatnow
 {
 
+/**
+ * UserTimeLineTable
+ * ------------------------------------------------------------------
+ * user_timeline 表的 DAO 封装（写扩散收件箱）。
+ *
+ * 关键变化（对齐新 schema）：
+ *   - 全局增量同步改用 user_seq 而非 message_id
+ *     —— 客户端只需保留一个游标即可拉跨会话所有新消息
+ *   - 会话维度查询改用 session_seq
+ *   - 投递状态从 bool is_read 合并到 deliver_status 枚举
+ *   - 新增 mark_delivered / mark_read：按 timeline 行更新投递状态
+ *   - latest_user_seq / unread_count_by_seq：客户端起始游标 / 未读计算入口
+ *   - 写操作保持"外部事务感知"：消息存储服务的"写消息 + 写 Timeline"是一个事务
+ * ------------------------------------------------------------------
+ */
 class UserTimeLineTable
 {
 public:
     using ptr = std::shared_ptr<UserTimeLineTable>;
     UserTimeLineTable(const std::shared_ptr<odb::core::database> &db) : _db(db) {}
-    /* brief: 插入（userTimeLine对象) */
-    bool insert(UserTimeline &userTimeline) {
-        try {
-            // 1. 检查外部是否已经开启了事务
-            bool has_external_trans = odb::transaction::has_current();
 
-            // 2. 如果外部没有事务，我们才开启一个本地事务；否则只创建一个空的 holder
-            // std::unique_ptr 用于管理事务对象的生命周期
+    /* brief: 单行插入；事务感知 */
+    bool insert(UserTimeline &tl) {
+        try {
+            bool has_external_trans = odb::transaction::has_current();
             std::unique_ptr<odb::transaction> local_trans;
-            
-            if (!has_external_trans) {
-                // 只有在没事务的时候，才由 DAO 开启
+            if(!has_external_trans) {
                 local_trans.reset(new odb::transaction(_db->begin()));
             }
-
-            // 3. 执行持久化操作 (ODB 会自动挂载到当前线程的活跃事务上)
-            _db->persist(userTimeline);
-
-            // 4. 只有当我们自己开启了事务，我们才负责提交
-            if (!has_external_trans) {
-                local_trans->commit();
-            }
-            
-            // 如果是外部事务，这里什么都不做，等外部 Service 去 commit
-
+            _db->persist(tl);
+            if(!has_external_trans) local_trans->commit();
         } catch(std::exception &e) {
-            LOG_ERROR("插入失败: {}", e.what());
-            throw; // 异常会向上传递，导致外部事务回滚
-        }
-        return true;
-    }
-    /* brief: 批量插入用户 Timeline (写扩散核心优化) */
-    bool insert(std::vector<UserTimeline> &timelines) {
-        if (timelines.empty()) {
-            return true;
-        }
-
-        try {
-            // 1. 检查外部是否已经开启了事务
-            bool has_external_trans = odb::transaction::has_current();
-            // 2. 如果外部没有事务，我们才开启一个本地事务；否则只创建一个空的 holder
-            // std::unique_ptr 用于管理事务对象的生命周期
-            std::unique_ptr<odb::transaction> local_trans;
-            
-            if (!has_external_trans) {
-                // 只有在没事务的时候，才由 DAO 开启
-                local_trans.reset(new odb::transaction(_db->begin()));
-            }
-
-            // 2. 循环持久化 (ODB 会自动优化 Prepared Statements)
-            for (auto &timeline : timelines) {
-                _db->persist(timeline);
-            }
-
-            // 4. 只有当我们自己开启了事务，我们才负责提交
-            if (!has_external_trans) {
-                local_trans->commit();
-            }
-
-            // 如果是外部事务，这里什么都不做，等外部 Service 去 commit
-        } catch(std::exception &e) {
-            LOG_ERROR("批量插入 Timeline 失败: 数量 {}, 错误: {}", timelines.size(), e.what());
+            LOG_ERROR("插入 timeline 失败: {}", e.what());
             throw;
         }
         return true;
     }
-    /* brief: 拉取最近未读消息, session_id 会话发给 user_id 的在 after_message_id 后的 limit 条消息 */
-    std::vector<UserTimeline> list_after(const std::string &user_id,
-                                        const std::string &session_id,
-                                        const unsigned long after_message_id,
-                                        size_t limit)
-    {
-        using query = odb::query<UserTimeline>;
-        using result = odb::result<UserTimeline>;
 
-        std::vector<UserTimeline> records;
-
+    /* brief: 批量插入（写扩散核心路径，群聊一条消息扩散 N 行）
+     *  - ODB 会自动复用 prepared statement
+     *  - 海量群（>1k 成员）建议在调用方按 user_id 分片落不同分片库
+     */
+    bool insert(std::vector<UserTimeline> &timelines) {
+        if(timelines.empty()) return true;
         try {
-            odb::transaction trans(_db->begin()); //获取事务对象，开启事务
-
-            result r(_db->query<UserTimeline>((query::user_id == user_id &&
-                                            query::session_id == session_id &&
-                                            query::message_id > after_message_id) +
-                                            (" ORDER BY " + query::message_id + " ASC" +
-                                            " LIMIT " + std::to_string(limit))));
-            // 在数据库利用建的复合索引读取出对应的 timeline
-
-            for(auto it = r.begin(); it != r.end(); ++it) {
-                records.emplace_back(*it);
+            bool has_external_trans = odb::transaction::has_current();
+            std::unique_ptr<odb::transaction> local_trans;
+            if(!has_external_trans) {
+                local_trans.reset(new odb::transaction(_db->begin()));
             }
-
-            trans.commit(); //提交事务
+            for(auto &tl : timelines) _db->persist(tl);
+            if(!has_external_trans) local_trans->commit();
         } catch(std::exception &e) {
-            LOG_ERROR("获取最近未读新消息失败: {}-{}", after_message_id, e.what());
-            return std::vector<UserTimeline>();
+            LOG_ERROR("批量插入 Timeline 失败 count={}: {}", timelines.size(), e.what());
+            throw;
         }
-        
-        return records;
+        return true;
     }
-    /* brief: 拉取历史消息, session_id 会话发给 user_id 的在 before_message_id 前的 limit 条历史消息 */
-    std::vector<UserTimeline> list_before(const std::string &user_id,
-                                        const std::string &session_id,
-                                        const unsigned long before_message_id,
-                                        size_t limit)
+
+    /* brief: 全局增量拉取 — 客户端跨会话的统一入口
+     *  - 走 idx_user_seq(user_id, user_seq) 索引
+     *  - 拉到 user_seq > after_user_seq 的 limit 条；ASC 保证顺序
+     */
+    std::vector<UserTimeline> list_global_after(const std::string &user_id,
+                                                unsigned long after_user_seq,
+                                                size_t limit)
     {
-        using query = odb::query<UserTimeline>;
-        using result = odb::result<UserTimeline>;
-
         std::vector<UserTimeline> records;
-
-        try {
-            odb::transaction trans(_db->begin()); //获取事务对象，开启事务
-
-            result r(_db->query<UserTimeline>((query::user_id == user_id &&
-                                            query::session_id == session_id &&
-                                            query::message_id < before_message_id) +
-                                            (" ORDER BY " + query::message_id + " DESC" +
-                                            " LIMIT " + std::to_string(limit))));
-            // 在数据库利用建的复合索引读取出对应的 timeline
-            for(auto it = r.begin(); it != r.end(); ++it) {
-                records.emplace_back(*it);
-            }
-
-            trans.commit(); //提交事务
-        } catch(std::exception &e) {
-            LOG_ERROR("获取历史消息失败: {}-{}", before_message_id, e.what());
-            return std::vector<UserTimeline>();
-        }
-
-        std::reverse(records.begin(), records.end());  // 这里需要反转一下，因为SQL查出来是新的前面，而客户端需要新消息追加在后面
-
-        return records;
-    }
-    /* brief: 拉取最近消息, session_id 会话发给 user_id 的离当前时间最近的 limit 条消息 */
-    std::vector<UserTimeline> list_latest(const std::string &user_id,
-                                        const std::string &session_id,
-                                        size_t limit)
-    {
-        using query = odb::query<UserTimeline>;
-        using result = odb::result<UserTimeline>;
-
-        std::vector<UserTimeline> records;
-
-        try {
-            odb::transaction trans(_db->begin()); //获取事务对象，开启事务
-
-            result r(_db->query<UserTimeline>((query::user_id == user_id &&
-                                            query::session_id == session_id) +
-                                            (" ORDER BY " + query::message_id + " DESC" +
-                                            " LIMIT " + std::to_string(limit))));
-            // 在数据库利用建的复合索引读取出对应的 timeline
-            for(auto it = r.begin(); it != r.end(); ++it) {
-                records.emplace_back(*it);
-            }                           
-            
-            trans.commit();
-        } catch(std::exception &e) {
-            LOG_ERROR("获取最近消息失败: {}", e.what());
-            return std::vector<UserTimeline>();
-        }
-
-        std::reverse(records.begin(), records.end()); //这次 DESC 从最后的数据拿 140 139 138... 方便索引命中, 因此需要反转一次保证顺序
-
-        return records;
-    }
-    /* brief: 判断timeline是否覆盖某个区间, 后期如果某时间点后的冷数据归档了，就需要降级从消息表取 */
-    bool exists(const std::string &user_id,
-                const std::string &session_id,
-                const unsigned long message_id)
-    {
-        using query = odb::query<UserTimeline>;
-        using result = odb::result<UserTimeline>;
-
-        std::vector<UserTimeline> records;
-        bool found = false;
-
-        try{
-            odb::transaction trans(_db->begin()); //获取事务对象，开启事务
-
-            result r(_db->query<UserTimeline>((query::user_id == user_id &&
-                                            query::session_id == session_id &&
-                                            query::message_id == message_id) + " LIMIT 1"));
-            
-            found = r.begin() != r.end();
-
-            trans.commit();
-        } catch(std::exception &e) {
-            LOG_ERROR("判断 timeline 是否覆盖某个区间失败: {}", e.what());
-            return false;
-        }
-
-        return found;
-    }
-    std::vector<UserTimeline> range(const std::string &user_id,
-                                const std::string &session_id,
-                                const boost::posix_time::ptime &stime,
-                                const boost::posix_time::ptime &etime)
-    {
-        using query = odb::query<UserTimeline>;
-        using result = odb::result<UserTimeline>;
-        std::vector<UserTimeline> records;
-
         try {
             odb::transaction trans(_db->begin());
-            
-            // 查询条件：指定用户 + 指定会话 + 时间在 [stime, etime] 之间
-            // 注意：这里利用了 UserTimeline 对象里的 _message_time 字段
+            using query  = odb::query<UserTimeline>;
+            using result = odb::result<UserTimeline>;
+            result r(_db->query<UserTimeline>(
+                (query::user_id == user_id && query::user_seq > after_user_seq) +
+                (" ORDER BY " + query::user_seq + " ASC LIMIT " + std::to_string(limit))));
+            for(auto &row : r) records.push_back(row);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("全局增量拉取失败 uid={} after={}: {}", user_id, after_user_seq, e.what());
+        }
+        return records;
+    }
+
+    /* brief: 会话内增量拉取（指定会话 seq 之后） */
+    std::vector<UserTimeline> list_session_after(const std::string &user_id,
+                                                 const std::string &session_id,
+                                                 unsigned long after_session_seq,
+                                                 size_t limit)
+    {
+        std::vector<UserTimeline> records;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<UserTimeline>;
+            using result = odb::result<UserTimeline>;
+            result r(_db->query<UserTimeline>(
+                (query::user_id == user_id &&
+                 query::session_id == session_id &&
+                 query::session_seq > after_session_seq) +
+                (" ORDER BY " + query::session_seq + " ASC LIMIT " + std::to_string(limit))));
+            for(auto &row : r) records.push_back(row);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("会话增量拉取失败 uid={} ssid={}: {}", user_id, session_id, e.what());
+        }
+        return records;
+    }
+
+    /* brief: 会话内倒翻历史（在某个 seq 之前 N 条） */
+    std::vector<UserTimeline> list_session_before(const std::string &user_id,
+                                                  const std::string &session_id,
+                                                  unsigned long before_session_seq,
+                                                  size_t limit)
+    {
+        std::vector<UserTimeline> records;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<UserTimeline>;
+            using result = odb::result<UserTimeline>;
+            result r(_db->query<UserTimeline>(
+                (query::user_id == user_id &&
+                 query::session_id == session_id &&
+                 query::session_seq < before_session_seq) +
+                (" ORDER BY " + query::session_seq + " DESC LIMIT " + std::to_string(limit))));
+            for(auto &row : r) records.push_back(row);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("会话历史拉取失败 uid={} ssid={}: {}", user_id, session_id, e.what());
+        }
+        std::reverse(records.begin(), records.end()); // 客户端按从旧到新展示
+        return records;
+    }
+
+    /* brief: 取会话内最近 N 条（首屏渲染） */
+    std::vector<UserTimeline> list_session_latest(const std::string &user_id,
+                                                  const std::string &session_id,
+                                                  size_t limit)
+    {
+        std::vector<UserTimeline> records;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<UserTimeline>;
+            using result = odb::result<UserTimeline>;
+            result r(_db->query<UserTimeline>(
+                (query::user_id == user_id && query::session_id == session_id) +
+                (" ORDER BY " + query::session_seq + " DESC LIMIT " + std::to_string(limit))));
+            for(auto &row : r) records.push_back(row);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("会话最近消息拉取失败 uid={} ssid={}: {}", user_id, session_id, e.what());
+        }
+        std::reverse(records.begin(), records.end());
+        return records;
+    }
+
+    /* brief: 时间段查询（兼容旧接口；新功能尽量按 seq） */
+    std::vector<UserTimeline> range(const std::string &user_id,
+                                    const std::string &session_id,
+                                    const boost::posix_time::ptime &stime,
+                                    const boost::posix_time::ptime &etime)
+    {
+        std::vector<UserTimeline> records;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<UserTimeline>;
+            using result = odb::result<UserTimeline>;
             result r(_db->query<UserTimeline>(
                 query::user_id == user_id &&
                 query::session_id == session_id &&
                 query::message_time >= stime &&
-                query::message_time <= etime
-            ));
-
-            for (auto it = r.begin(); it != r.end(); ++it) {
-                records.emplace_back(*it);
-            }
-            trans.commit();
-        } catch (std::exception &e) {
-            LOG_ERROR("获取时间段Timeline失败: {} - {}: {}", 
-                boost::posix_time::to_simple_string(stime), 
-                boost::posix_time::to_simple_string(etime), e.what());
-        }
-        return records;
-    }
-    /* brief: 全局增量拉取。获取该用户(跨所有会话)在 after_message_id 之后的消息 */
-    std::vector<UserTimeline> list_global_after(const std::string &user_id,
-                                                unsigned long after_message_id,
-                                                size_t limit)
-    {
-        using query = odb::query<UserTimeline>;
-        using result = odb::result<UserTimeline>;
-        std::vector<UserTimeline> records;
-
-        try {
-            odb::transaction trans(_db->begin());
-
-            // 核心查询：只看 user_id，忽略 session_id
-            // 必须按 message_id 升序 (ASC)，因为是拉取“新”消息
-            result r(_db->query<UserTimeline>(
-                (query::user_id == user_id && query::message_id > after_message_id) +
-                (" ORDER BY " + query::message_id + " ASC" +
-                 " LIMIT " + std::to_string(limit))
-            ));
-
-            for(auto it = r.begin(); it != r.end(); ++it) {
-                records.emplace_back(*it);
-            }
+                query::message_time <= etime));
+            for(auto &row : r) records.push_back(row);
             trans.commit();
         } catch(std::exception &e) {
-            LOG_ERROR("全局增量拉取失败: uid={}, last_id={}, err={}", user_id, after_message_id, e.what());
+            LOG_ERROR("时间段查询失败: {}", e.what());
         }
         return records;
     }
-    // 【新增】获取该会话中最新的消息 ID
-    unsigned long get_latest_msg_id(const std::string &user_id, const std::string &session_id) {
-        using query = odb::query<LatestIdView>;
-        using result = odb::result<LatestIdView>;
-        
-        unsigned long max_id = 0;
+
+    /* brief: 取该用户当前最大 user_seq — 客户端首次连入时用作起始游标
+     *  - 也可用于 max(user_seq) 监控告警
+     */
+    unsigned long latest_user_seq(const std::string &user_id) {
+        unsigned long max_seq = 0;
         try {
             odb::transaction trans(_db->begin());
-            // 查询：user_id + session_id 下的最大 message_id
-            result r(_db->query<LatestIdView>(
-                odb::query<UserTimeline>::user_id == user_id && 
-                odb::query<UserTimeline>::session_id == session_id
-            ));
-            
-            if (!r.empty()) {
-                auto v = *r.begin();
-                if (!v.max_id.null()) {
-                    max_id = *v.max_id;
-                }
-            }
+            using query  = odb::query<UserTimeline>;
+            using result = odb::result<UserTimeline>;
+            result r(_db->query<UserTimeline>(
+                (query::user_id == user_id) +
+                (" ORDER BY " + query::user_seq + " DESC LIMIT 1")));
+            auto it = r.begin();
+            if(it != r.end()) max_seq = it->user_seq();
             trans.commit();
-        } catch (std::exception &e) {
-            LOG_ERROR("获取最新ID失败: {}", e.what());
+        } catch(std::exception &e) {
+            LOG_ERROR("取用户最大 user_seq 失败 {}: {}", user_id, e.what());
         }
-        return max_id;
+        return max_seq;
     }
 
-    // 【新增】统计 last_read_id 之后的消息数量
-    int get_unread_count(const std::string &user_id, 
-                         const std::string &session_id, 
-                         unsigned long last_read_id) 
-    {
-        using query = odb::query<CountView>;
-        using result = odb::result<CountView>;
+    /* brief: 取该用户在会话内的最大 session_seq */
+    unsigned long latest_session_seq(const std::string &user_id, const std::string &session_id) {
+        unsigned long max_seq = 0;
+        try {
+            odb::transaction trans(_db->begin());
+            using query  = odb::query<UserTimeline>;
+            using result = odb::result<UserTimeline>;
+            result r(_db->query<UserTimeline>(
+                (query::user_id == user_id && query::session_id == session_id) +
+                (" ORDER BY " + query::session_seq + " DESC LIMIT 1")));
+            auto it = r.begin();
+            if(it != r.end()) max_seq = it->session_seq();
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("取会话最大 session_seq 失败 {}-{}: {}", user_id, session_id, e.what());
+        }
+        return max_seq;
+    }
 
+    /* brief: 计算 last_read_seq 之后的未读条数 */
+    int unread_count_by_seq(const std::string &user_id,
+                            const std::string &session_id,
+                            unsigned long last_read_seq)
+    {
         int count = 0;
         try {
             odb::transaction trans(_db->begin());
-            // 查询：user_id + session_id 且 message_id > last_read_id 的数量
+            using query  = odb::query<CountView>;
+            using result = odb::result<CountView>;
             result r(_db->query<CountView>(
-                odb::query<UserTimeline>::user_id == user_id && 
+                odb::query<UserTimeline>::user_id == user_id &&
                 odb::query<UserTimeline>::session_id == session_id &&
-                odb::query<UserTimeline>::message_id > last_read_id
-            ));
-
-            if (!r.empty()) {
-                count = (int)r.begin()->count;
-            }
+                odb::query<UserTimeline>::session_seq > last_read_seq));
+            auto it = r.begin();
+            if(it != r.end()) count = static_cast<int>(it->count);
             trans.commit();
-        } catch (std::exception &e) {
-            LOG_ERROR("获取未读数失败: {}", e.what());
+        } catch(std::exception &e) {
+            LOG_ERROR("未读计算失败: {}", e.what());
         }
         return count;
     }
+
+    /* brief: 标送达 — 多端送达回执 */
+    bool mark_delivered(const std::string &user_id, unsigned long message_id) {
+        return _set_status(user_id, message_id, TimelineDeliverStatus::DELIVERED);
+    }
+
+    /* brief: 标已读 — 单聊 / 被 @ 等场景 */
+    bool mark_read(const std::string &user_id, unsigned long message_id) {
+        return _set_status(user_id, message_id, TimelineDeliverStatus::READ);
+    }
+
+    /* brief: 物理清理某用户某会话的 Timeline（用户主动"清空聊天记录"） */
+    bool remove_by_user_session(const std::string &user_id, const std::string &session_id) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserTimeline>;
+            _db->erase_query<UserTimeline>(
+                query::user_id == user_id && query::session_id == session_id);
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("清理用户会话 Timeline 失败 {}-{}: {}", user_id, session_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
 private:
+    bool _set_status(const std::string &user_id, unsigned long message_id, TimelineDeliverStatus s) {
+        try {
+            odb::transaction trans(_db->begin());
+            using query = odb::query<UserTimeline>;
+            std::shared_ptr<UserTimeline> tl(_db->query_one<UserTimeline>(
+                query::user_id == user_id && query::message_id == message_id));
+            if(!tl) {
+                trans.commit();
+                return false;
+            }
+            // 仅允许状态向前推进：PENDING < DELIVERED < READ
+            if(static_cast<int>(s) > static_cast<int>(tl->deliver_status())) {
+                tl->deliver_status(s);
+                _db->update(*tl);
+            }
+            trans.commit();
+        } catch(std::exception &e) {
+            LOG_ERROR("更新 timeline 状态失败 {}-{}: {}", user_id, message_id, e.what());
+            return false;
+        }
+        return true;
+    }
+
     std::shared_ptr<odb::core::database> _db;
 };
 


### PR DESCRIPTION
基于 #5（ODB schema 重构）继续完成业务层 DAO 适配。

## Summary
对齐新版 ODB schema，重写 7 个旧 DAO + 新增 4 个 DAO。

### 旧 DAO 重写
- **mysql_user**：手机号登录入口；登录回写 last_login_time/ip；账号状态机；批量查询改 \`in_range\` 防注入
- **mysql_relation**：双向关系软删除（DELETED 而非 erase）；备注/分组/星标/拉黑接口
- **mysql_friend_apply**：状态机化（\`update_status\`）；待处理列表走 \`idx_peer_status_time\`；防骚扰判重 \`exists_pending\`
- **mysql_chat_session**：删 last_message_* 接口；\`select_single_by_peer\` 基于 peer_user_id 零 self-join；\`bump_max_seq\` 单向递增；\`dismiss\` 软删除
- **mysql_chat_session_member**：退群 \`set_quit\`、二次入群 \`rejoin\` 复用旧行；已读/送达游标改 seq 维度；列表 ORDER BY 改用 \`max_seq + update_time\`
- **mysql_message**：查询路径改 \`(session_id, seq_id)\`；\`select_by_client_msg\` 幂等去重；\`recent_by_seq\` / \`range_by_seq\` / \`max_seq_of_session\`；\`mark_revoked\` / \`mark_deleted\`
- **mysql_user_timeline**：增量同步切到 \`user_seq\`；会话级 \`session_seq\` 游标；\`mark_delivered/read\` 状态机；\`is_read\` 合并到 \`TimelineDeliverStatus\`

### 新增 DAO
- **mysql_user_device**：upsert 登录/心跳/在线设备列表/强制下线/push_token 全局迁移
- **mysql_message_read**：群消息已读回执，单条 ack 与批量 ack
- **mysql_message_attachment**：多附件场景批量 insert + 单/批 list
- **mysql_message_mention**：@ 提及独立成行，\`user_id=\"*\"\` 约定 @全体；\`list_my_mentions\` 走 \`idx_user_msg\` 反查"被 @ 列表"

### 通用约定
- 所有 \`mark_*\` / \`set_*\` 类接口仅在状态向前推进时写入，避免回退
- 写事务感知：message/timeline/attachment/mention 支持挂载到外部事务，便于消息存储服务"消息+timeline+附件"一个事务原子落库
- 批量查询全部改用 \`odb::query::xxx.in_range\`

## Test plan
- [ ] 业务层 5 个服务（user/friend/chatsession/transmite/message）调用点同步切换：
  - friend_server: \`apply_users()\` → \`select_pending()\`，\`exists()\` → \`exists_pending()\`
  - chatsession_server: 移除 \`singleChatSession()\` / \`groupChatSession()\` 调用，统一用 \`OrderedChatSessionView.peer_user_id\`
  - message_server: \`recent()\` → \`recent_by_seq()\`，落库前调 \`select_by_client_msg\` 去重
  - transmite_server: 写消息时同时写 attachment / mention 子表
- [ ] ODB \`odb -d mysql --std c++17 --generate-query --generate-schema *.hxx\` 跑通
- [ ] CMakeLists.txt 加新 \`*.hxx\`/\`*-odb.hxx\` 入口
- [ ] Redis Key 上线：\`seq:{ssid}\` / \`user_seq:{uid}\` / \`chat:last:{ssid}\` / \`read:{mid}\`