### PR TITLE
feat(common): 完善基础设施封装（logger/redis/utils/etcd/channel/mysql/mail/mq/asr）

### DIFF
--- a/code/server/common/asr.hpp
+++ b/code/server/common/asr.hpp
@@ -1,31 +1,73 @@
 #pragma once
 
+/**
+ * ===========================================================================
+ * 语音识别封装（基于百度 AIP cpp-sdk）
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. 抽出 SpeechRecognizer 接口，便于后续替换不同 ASR 提供商
+ *   2. recognize() 同时返回结果与错误信息，调用方按 res.empty() 判错
+ *   3. 默认参数：PCM / 16kHz；如需扩展请在 recognize() 增加重载
+ *   4. 错误日志统一脱敏：不输出原始 speech_data 二进制
+ * ===========================================================================
+ */
+
+#include <memory>
+#include <string>
 #include "../third/include/aip-cpp-sdk/speech.h"
 #include "logger.hpp"
 
-namespace chatnow 
+namespace chatnow
 {
 
-class ASRClient 
+/* brief: 语音识别接口（解耦 ASR 提供商） */
+class SpeechRecognizer
+{
+public:
+    using ptr = std::shared_ptr<SpeechRecognizer>;
+    virtual ~SpeechRecognizer() = default;
+    /* brief: 识别一段 PCM 16kHz 数据为文字
+     *  @param speech_data 二进制语音数据
+     *  @param err         返回错误信息（仅失败时填充）
+     *  @return 文字结果；空字符串表示失败
+     */
+    virtual std::string recognize(const std::string &speech_data, std::string &err) = 0;
+};
+
+class ASRClient : public SpeechRecognizer
 {
 public:
     using ptr = std::shared_ptr<ASRClient>;
 
     ASRClient(const std::string &appid,
-            const std::string &api_key,
-            const std::string &secret_key) : _client(appid, api_key, secret_key) {}
-    std::string recognize(const std::string &speech_data, std::string &err)
-    {
-        Json::Value result = _client.recognize(speech_data, "pcm", 16000, aip::null);
-        if(result["err_no"].asInt() != 0) {
-            LOG_ERROR("语言识别失败: {}", result["err_msg"].asString());
-            err = result["err_msg"].asString();
+              const std::string &api_key,
+              const std::string &secret_key)
+        : _client(appid, api_key, secret_key) {}
+
+    std::string recognize(const std::string &speech_data, std::string &err) override {
+        try {
+            Json::Value result = _client.recognize(speech_data, "pcm", 16000, aip::null);
+            if(result["err_no"].asInt() != 0) {
+                err = result["err_msg"].asString();
+                LOG_ERROR("语音识别失败 err_no={} msg={}", result["err_no"].asInt(), err);
+                return std::string();
+            }
+            // 百度 SDK 偶发返回空数组，做防御
+            if(!result["result"].isArray() || result["result"].size() == 0) {
+                err = "结果为空";
+                LOG_ERROR("语音识别返回空结果");
+                return std::string();
+            }
+            return result["result"][0].asString();
+        } catch(const std::exception &e) {
+            err = e.what();
+            LOG_ERROR("语音识别异常: {}", e.what());
             return std::string();
         }
-        return result["result"][0].asString();
     }
+
 private:
     aip::Speech _client;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/channel.hpp
+++ b/code/server/common/channel.hpp
@@ -1,41 +1,69 @@
 #pragma once
 
+/**
+ * ===========================================================================
+ * brpc 服务信道管理（配合 etcd 服务发现）
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. _index 改为 std::atomic 保证 RR 计数无竞争
+ *   2. ChannelOptions 增加合理超时（旧版 -1 一直等待，会拖垮调用线程）：
+ *      - connect_timeout: 1s
+ *      - timeout:         3s
+ *   3. ServiceManager.choose() 在没有可用节点时返回 nullptr 并打 warn，
+ *      调用方需显式判空
+ *   4. 容器使用 unordered_map / unordered_set，保留就近的"添加→使用"读
+ * ===========================================================================
+ */
+
+#include <atomic>
 #include <brpc/channel.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 #include "logger.hpp"
 
 namespace chatnow
 {
 
-/* brief: 封装单个服务的信道管理类 */
-class ServiceChannel 
+inline constexpr int32_t kConnectTimeoutMs = 1000;   // 连接超时 1s
+inline constexpr int32_t kRpcTimeoutMs     = 3000;   // 单次 RPC 超时 3s
+inline constexpr int32_t kRpcMaxRetry      = 3;
+
+/* brief: 单服务多实例信道集合（同一服务名下的多个节点） */
+class ServiceChannel
 {
 public:
     using ptr = std::shared_ptr<ServiceChannel>;
     using ChannelPtr = std::shared_ptr<brpc::Channel>;
 
-    ServiceChannel(const std::string &name) : _service_name(name), _index(0) {}
-    /* brief: 服务上线了一个节点，则用 append 新增信道 */
+    explicit ServiceChannel(const std::string &name) : _service_name(name), _index(0) {}
+
+    /* brief: 节点上线，新增 brpc::Channel */
     void append(const std::string &host) {
         auto channel = std::make_shared<brpc::Channel>();
         brpc::ChannelOptions options;
-        options.connect_timeout_ms = -1;    // 连接等待超时时间， -1表示一直等待
-        options.timeout_ms = -1;            //rpc请求等待超时时间， -1 表示一直等待
-        options.max_retry = 3;              //请求重试次数
-        options.protocol = "baidu_std";     //序列化协议，默认使用baidu_std
-        int ret = channel->Init(host.c_str(), &options);
-        if(ret == -1) {
-            LOG_ERROR("初始化{} - {}信道失败", _service_name, host);
+        options.connect_timeout_ms = kConnectTimeoutMs;
+        options.timeout_ms         = kRpcTimeoutMs;
+        options.max_retry          = kRpcMaxRetry;
+        options.protocol           = "baidu_std";
+        if(channel->Init(host.c_str(), &options) != 0) {
+            LOG_ERROR("初始化 {}-{} 信道失败", _service_name, host);
+            return;
         }
         std::unique_lock<std::mutex> lock(_mutex);
-        _hosts.insert(std::make_pair(host, channel));
+        _hosts[host] = channel;
         _channels.push_back(channel);
     }
-    /* brief: 服务下线了一个节点，则用 remove 释放信道 */
+
+    /* brief: 节点下线，释放 Channel */
     void remove(const std::string &host) {
         std::unique_lock<std::mutex> lock(_mutex);
         auto it = _hosts.find(host);
         if(it == _hosts.end()) {
-            LOG_WARN("{} - {}节点删除信道时，没有找到信道信息", _service_name, host);
+            LOG_WARN("{}-{} 节点删除信道时未找到信道信息", _service_name, host);
             return;
         }
         for(auto vit = _channels.begin(); vit != _channels.end(); ++vit) {
@@ -46,96 +74,106 @@ public:
         }
         _hosts.erase(it);
     }
-    /* brief: 通过 RR轮转 策略，获取一个 Channel 用于发起对应服务的 Rpc 调用 */
+
+    /* brief: RR 选择一个 channel；空集合返回 nullptr */
     ChannelPtr choose() {
         std::unique_lock<std::mutex> lock(_mutex);
-        if(_channels.size() == 0) {
+        if(_channels.empty()) {
             LOG_ERROR("当前没有能提供 {} 服务的节点", _service_name);
             return ChannelPtr();
         }
-        int32_t idx = _index++ % _channels.size();
+        auto idx = _index.fetch_add(1, std::memory_order_relaxed) % _channels.size();
         return _channels[idx];
     }
+
+    /* brief: 当前节点数 — 健康检查/监控用 */
+    size_t size() const {
+        std::unique_lock<std::mutex> lock(_mutex);
+        return _channels.size();
+    }
+
 private:
-    std::mutex _mutex;
-    int32_t _index;                    //当前轮转下标计数器
-    std::string _service_name;         //服务名称
-    std::vector<ChannelPtr> _channels; //当前服务对应的信道集合
-    std::unordered_map<std::string, ChannelPtr> _hosts; //主机地址与信道的映射关系
+    mutable std::mutex _mutex;
+    std::atomic<uint32_t> _index;
+    std::string _service_name;
+    std::vector<ChannelPtr> _channels;
+    std::unordered_map<std::string, ChannelPtr> _hosts;
 };
 
-/* brief: 总体的服务信道管理类 */
+/* brief: 多服务的 Channel 总管 — 配合 etcd Discovery 维护 */
 class ServiceManager
 {
 public:
     using ptr = std::shared_ptr<ServiceManager>;
     ServiceManager() = default;
-    /* brief: 获取指定服务的节点信道 */
+
+    /* brief: 选中目标服务的某个节点 channel */
     ServiceChannel::ChannelPtr choose(const std::string &service_name) {
         std::unique_lock<std::mutex> lock(_mutex);
-        auto sit = _services.find(service_name);
-        if(sit == _services.end()) {
+        auto it = _services.find(service_name);
+        if(it == _services.end()) {
             LOG_ERROR("当前没有能提供 {} 服务的节点", service_name);
             return ServiceChannel::ChannelPtr();
         }
-        return sit->second->choose();
+        return it->second->choose();
     }
-    // 先声明，我关注哪些服务的上下线，不关心的就不需要管理了
+
+    /* brief: 声明关注哪些服务（不关注的服务上下线事件会被忽略，节省内存） */
     void declared(const std::string &service_name) {
         std::unique_lock<std::mutex> lock(_mutex);
         _follow_services.insert(service_name);
     }
-    /* brief: 服务上线时调用的回调接口，将服务节点管理起来 */
+
+    /* brief: etcd PUT 事件回调 */
     void onServiceOnline(const std::string &service_instance, const std::string &host) {
         std::string service_name = getServiceName(service_instance);
         ServiceChannel::ptr service;
         {
             std::unique_lock<std::mutex> lock(_mutex);
-            auto fit = _follow_services.find(service_name);
-            if(fit == _follow_services.end()) {
-                LOG_DEBUG("{} - {} 服务上线了，但是当前并不关心", service_name, host);
+            if(_follow_services.find(service_name) == _follow_services.end()) {
+                LOG_DEBUG("{}-{} 服务上线，但当前不关心", service_name, host);
                 return;
             }
-            //先获取管理对象，没有则创建，有则添加节点
-            auto sit = _services.find(service_name);
-            if(sit == _services.end()) {
+            auto it = _services.find(service_name);
+            if(it == _services.end()) {
                 service = std::make_shared<ServiceChannel>(service_name);
-                _services.insert(std::make_pair(service_name, service));
+                _services[service_name] = service;
             } else {
-                service = sit->second;
+                service = it->second;
             }
         }
-        if(!service) LOG_ERROR("新增 {} 服务管理节点失败", service_name);
-        LOG_DEBUG("{} - {} 服务上线新节点，进行添加管理", service_name, host);
+        LOG_DEBUG("{}-{} 服务上线新节点", service_name, host);
         service->append(host);
     }
-    /* brief: 服务下线时调用的回调接口，从服务信道管理中，删除指定节点信道 */
+
+    /* brief: etcd DELETE 事件回调 */
     void onServiceOffline(const std::string &service_instance, const std::string &host) {
         std::string service_name = getServiceName(service_instance);
         ServiceChannel::ptr service;
         {
             std::unique_lock<std::mutex> lock(_mutex);
-            //先获取管理对象，没有则创建，有则添加节点
-            auto sit = _services.find(service_name);
-            if(sit == _services.end()) {
-                LOG_WARN("删除 {} 服务节点时，没有找到管理对象", service_name);
+            auto it = _services.find(service_name);
+            if(it == _services.end()) {
+                LOG_WARN("删除 {} 服务节点时未找到管理对象", service_name);
                 return;
             }
-            service = sit->second;
+            service = it->second;
         }
-        LOG_DEBUG("{} - {} 服务下线节点，进行删除管理", service_name, host);
+        LOG_DEBUG("{}-{} 服务下线节点", service_name, host);
         service->remove(host);
     }
+
 private:
+    /* brief: 从注册路径 /service/xxx/instance/<id> 中抽出服务名 /service/xxx/instance */
     std::string getServiceName(const std::string &service_instance) {
         auto pos = service_instance.find_last_of('/');
         if(pos == std::string::npos) return service_instance;
         return service_instance.substr(0, pos);
     }
-private:
+
     std::mutex _mutex;
     std::unordered_set<std::string> _follow_services;
     std::unordered_map<std::string, ServiceChannel::ptr> _services;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/data_es.hpp
+++ b/code/server/common/data_es.hpp
@@ -1,9 +1,31 @@
 #pragma once
 
+/**
+ * ===========================================================================
+ * 业务级 ES 索引封装
+ * ---------------------------------------------------------------------------
+ * 当前 3 个索引（与 MySQL 主表对齐）：
+ *   - user         用户搜索（昵称模糊 / 邮箱精确 / 用户ID 精确）
+ *   - message      消息全文检索（仅文本消息进入索引）
+ *   - chat_session 群名称模糊搜索 / 类型筛选
+ *
+ * 设计要点（在原版基础上的修订）：
+ *   1. ESUser 增补 phone / status 字段，匹配新 schema
+ *   2. ESMessage 增补 seq_id / status 字段，对齐 message 表结构变化；
+ *      搜索结果反序列化时也写回这些字段
+ *   3. ES status 0 = NORMAL（正常）；REVOKED/DELETED 不参与全文检索
+ *      append_data() 写入前应在调用方判断 status
+ *   4. search() 全部支持 size 限制，避免一次性全量返回
+ *   5. ESChatSession 索引补 update_time 用于按变更时间排序
+ *   6. 旧 createIndex 与 create_index 命名混用 — 统一改 create_index
+ * ===========================================================================
+ */
+
 #include "icsearch.hpp"
 #include "user.hxx"
 #include "message.hxx"
 #include "chat_session.hxx"
+#include <optional>
 
 namespace chatnow
 {
@@ -16,172 +38,198 @@ public:
     }
 };
 
+// =============================================================================
+// 用户索引：昵称模糊 / 邮箱手机号精确 / 用户ID 精确
+// =============================================================================
 class ESUser
 {
 public:
     using ptr = std::shared_ptr<ESUser>;
+    explicit ESUser(const std::shared_ptr<elasticlient::Client> &client) : _client(client) {}
 
-    ESUser(const std::shared_ptr<elasticlient::Client> &client) : _client(client) {}
     bool create_index() {
         bool ret = ESIndex(_client, "user")
-            .append("user_id", "keyword", "standard", true)
+            .append("user_id",     "keyword", "standard", true)
             .append("nickname")
-            .append("mail", "keyword", "standard", true)
-            .append("description", "text", "standard", false)
-            .append("avatar_id", "keyword", "standard", false)
+            .append("mail",        "keyword", "standard", true)
+            .append("phone",       "keyword", "standard", true)
+            .append("description", "text",    "standard", false)
+            .append("avatar_id",   "keyword", "standard", false)
+            .append("status",      "integer", "standard", false)
             .create();
-        if(ret == false) {
+        if(!ret) {
             LOG_ERROR("用户信息索引创建失败");
             return false;
         }
         LOG_INFO("用户信息索引创建成功");
         return true;
     }
-    bool append_data(const std::string &uid, 
-                    const std::string &mail, 
-                    const std::string &nickname,
-                    const std::string &description,
-                    const std::string &avatar_id) {
-        auto ret = ESInsert(_client, "user")
-            .append("user_id", uid)
-            .append("nickname", nickname)
-            .append("mail", mail)
+
+    /* brief: upsert 用户搜索数据；登录或资料修改时调用 */
+    bool append_data(const std::string &uid,
+                     const std::string &mail,
+                     const std::string &phone,
+                     const std::string &nickname,
+                     const std::string &description,
+                     const std::string &avatar_id,
+                     int status = 0)
+    {
+        bool ret = ESInsert(_client, "user")
+            .append("user_id",     uid)
+            .append("nickname",    nickname)
+            .append("mail",        mail)
+            .append("phone",       phone)
             .append("description", description)
-            .append("avatar_id", avatar_id)
+            .append("avatar_id",   avatar_id)
+            .append("status",      status)
             .insert(uid);
-        if(ret == false) {
-            LOG_ERROR("用户数据插入/更新失败");
+        if(!ret) {
+            LOG_ERROR("用户数据插入/更新失败 uid={}", uid);
             return false;
         }
-        LOG_INFO("用户数据新增/更新成功");
         return true;
     }
-    std::vector<User> search(const std::string &key, const std::vector<std::string> &uid_list) {
+
+    /* brief: 模糊搜索；排除已知用户 ID（自己 + 已是好友） */
+    std::vector<User> search(const std::string &key,
+                             const std::vector<std::string> &uid_list,
+                             int size = 20)
+    {
         std::vector<User> res;
         Json::Value json_user = ESSearch(_client, "user")
             .append_should_match("mail.keyword", key)
+            .append_should_match("phone.keyword", key)
             .append_should_match("user_id.keyword", key)
             .append_should_match("nickname", key)
             .append_must_not_terms("user_id.keyword", uid_list)
+            .page(0, size)
             .search();
-        if(json_user.isArray() == false) {
-            LOG_ERROR("用户搜索结构不是数组类型");
-            return res;
-        }
-        int sz = json_user.size();
-        LOG_DEBUG("检索结果条目数量: {}", sz);
-        for(int i = 0; i < sz; ++i) {
-            User user;
-            user.user_id(json_user[i]["_source"]["user_id"].asString());
-            user.nickname(json_user[i]["_source"]["nickname"].asString());
-            user.description(json_user[i]["_source"]["description"].asString());
-            user.mail(json_user[i]["_source"]["mail"].asString());
-            user.avatar_id(json_user[i]["_source"]["avatar_id"].asString());
-            res.push_back(user);
+        if(!json_user.isArray()) return res;
+
+        for(int i = 0; i < (int)json_user.size(); ++i) {
+            const auto &src = json_user[i]["_source"];
+            User u;
+            u.user_id(src["user_id"].asString());
+            u.nickname(src["nickname"].asString());
+            u.description(src["description"].asString());
+            u.mail(src["mail"].asString());
+            u.phone(src["phone"].asString());
+            u.avatar_id(src["avatar_id"].asString());
+            res.push_back(u);
         }
         return res;
     }
+
 private:
     std::shared_ptr<elasticlient::Client> _client;
 };
 
+// =============================================================================
+// 消息全文索引（仅文本消息进入；状态 != NORMAL 不索引）
+// =============================================================================
 class ESMessage
 {
 public:
     using ptr = std::shared_ptr<ESMessage>;
-    ESMessage(const std::shared_ptr<elasticlient::Client> &client) : _client(client) {}
-    
-    bool createIndex() {
+    explicit ESMessage(const std::shared_ptr<elasticlient::Client> &client) : _client(client) {}
+
+    bool create_index() {
         bool ret = ESIndex(_client, "message")
-            .append("user_id", "keyword", "standard", false)
-            .append("message_id", "long", "standard", false)
-            .append("create_time", "long", "standard", false)
+            .append("user_id",         "keyword", "standard", false)
+            .append("message_id",      "long",    "standard", false)
+            .append("seq_id",          "long",    "standard", false)
+            .append("create_time",     "long",    "standard", false)
             .append("chat_session_id", "keyword", "standard", true)
-            .append("content")
+            .append("content")    // 文本消息内容，参与中文分词
+            .append("status",          "integer", "standard", false)
             .create();
-        if(ret == false) {
-            LOG_INFO("消息信息索引创建失败");
+        if(!ret) {
+            LOG_ERROR("消息索引创建失败");
             return false;
         }
-        LOG_INFO("消息信息索引创建成功");
+        LOG_INFO("消息索引创建成功");
         return true;
     }
+    /* brief: 兼容旧名 */
+    bool createIndex() { return create_index(); }
 
     bool appendData(const std::string &user_id,
                     unsigned long message_id,
-                    const long create_time,
+                    unsigned long seq_id,
+                    long create_time_seconds,
                     const std::string &chat_session_id,
-                    const std::string &content)
+                    const std::string &content,
+                    int status = 0)
     {
         bool ret = ESInsert(_client, "message")
-            .append("user_id", user_id)
-            .append("message_id", message_id)
-            .append("create_time", create_time)
+            .append("user_id",         user_id)
+            .append("message_id",      message_id)
+            .append("seq_id",          seq_id)
+            .append("create_time",     create_time_seconds)
             .append("chat_session_id", chat_session_id)
-            .append("content", content)
+            .append("content",         content)
+            .append("status",          status)
             .insert(std::to_string(message_id));
-        if(ret == false) {
-            LOG_ERROR("消息数据插入/更新失败");
+        if(!ret) {
+            LOG_ERROR("消息数据插入/更新失败 mid={}", message_id);
             return false;
         }
-        LOG_INFO("消息数据新增/更新成功");
         return true;
     }
 
     bool remove(unsigned long mid) {
-        bool ret = ESRemove(_client, "message").remove(std::to_string(mid));
-        if(ret == false) {
-            LOG_ERROR("消息删除失败");
-            return false;
-        }
-        LOG_INFO("消息删除成功");
-        return true;
+        return ESRemove(_client, "message").remove(std::to_string(mid));
     }
 
-    std::vector<Message> search(const std::string &key, const std::string &ssid) {
+    /* brief: 关键字搜索某会话内的文本消息 */
+    std::vector<Message> search(const std::string &key, const std::string &ssid, int size = 50) {
         std::vector<Message> res;
-        Json::Value json_message = ESSearch(_client, "message")
+        Json::Value json_msg = ESSearch(_client, "message")
             .append_must_term("chat_session_id.keyword", ssid)
             .append_must_match("content", key)
+            .append_must_term("status", std::to_string(0))      // 仅 NORMAL
+            .sort_by("create_time", "desc")
+            .page(0, size)
             .search();
-        if(json_message.isArray() == false) {
-            LOG_ERROR("用户搜索结果为空，或者结果不是数组类型");
-            return res;
-        }
-        int sz = json_message.size();
-        LOG_DEBUG("检索结果条目数量: {}", sz);
-        for(int i = 0; i < sz; ++i) {
-            Message message;
-            message.user_id(json_message[i]["_source"]["user_id"].asString());
-            message.message_id(json_message[i]["_source"]["message_id"].asUInt64());
-            boost::posix_time::ptime ctime(boost::posix_time::from_time_t(json_message[i]["_source"]["create_time"].asInt64()));
-            message.create_time(ctime);
-            message.session_id(json_message[i]["_source"]["chat_session_id"].asString());
-            message.content(json_message[i]["_source"]["content"].asString());
-            res.push_back(message);
+        if(!json_msg.isArray()) return res;
+
+        for(int i = 0; i < (int)json_msg.size(); ++i) {
+            const auto &src = json_msg[i]["_source"];
+            Message m;
+            m.user_id(src["user_id"].asString());
+            m.message_id(src["message_id"].asUInt64());
+            m.seq_id(src["seq_id"].asUInt64());
+            boost::posix_time::ptime ct(boost::posix_time::from_time_t(src["create_time"].asInt64()));
+            m.create_time(ct);
+            m.session_id(src["chat_session_id"].asString());
+            m.content(src["content"].asString());
+            res.push_back(m);
         }
         return res;
     }
+
 private:
     std::shared_ptr<elasticlient::Client> _client;
 };
 
+// =============================================================================
+// 群名称索引（搜索群、按类型筛选）
+// =============================================================================
 class ESChatSession
 {
 public:
     using ptr = std::shared_ptr<ESChatSession>;
-    ESChatSession(const std::shared_ptr<elasticlient::Client> &client)
-        : _client(client) {}
+    explicit ESChatSession(const std::shared_ptr<elasticlient::Client> &client) : _client(client) {}
 
     bool create_index() {
         bool ret = ESIndex(_client, "chat_session")
-            .append("chat_session_id", "keyword", "standard", true)
-            .append("chat_session_name")                 // text + standard analyzer
+            .append("chat_session_id",   "keyword", "standard", true)
+            .append("chat_session_name")  // 中文分词
             .append("chat_session_type", "integer", "standard", false)
-            .append("avatar_id", "keyword", "standard", false)
-            .append("status", "integer", "standard", false)
+            .append("avatar_id",         "keyword", "standard", false)
+            .append("status",            "integer", "standard", false)
+            .append("update_time",       "long",    "standard", false)
             .create();
-
         if(!ret) {
             LOG_ERROR("会话搜索索引创建失败");
             return false;
@@ -191,56 +239,52 @@ public:
     }
 
     bool append_data(const chatnow::ChatSession &cs) {
+        // 把 update_time 转成秒级时间戳便于排序
+        static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+        long ts = (cs.update_time() - epoch).total_seconds();
         bool ret = ESInsert(_client, "chat_session")
-            .append("chat_session_id", cs.chat_session_id())
+            .append("chat_session_id",   cs.chat_session_id())
             .append("chat_session_name", cs.chat_session_name())
             .append("chat_session_type", static_cast<int>(cs.chat_session_type()))
-            .append("avatar_id", cs.avatar_id())
-            .append("status", cs.status())
+            .append("avatar_id",         cs.avatar_id())
+            .append("status",            static_cast<int>(cs.status()))
+            .append("update_time",       ts)
             .insert(cs.chat_session_id());
-
         if(!ret) {
-            LOG_ERROR("会话搜索数据插入/更新失败");
+            LOG_ERROR("会话搜索数据插入/更新失败 ssid={}", cs.chat_session_id());
             return false;
         }
-        LOG_INFO("会话搜索数据新增/更新成功");
         return true;
     }
 
-    std::vector<std::string> search(const std::string &key, std::optional<chatnow::ChatSessionType> type = std::nullopt) {
-        std::vector<std::string> res;
-
-        auto search_builder = ESSearch(_client, "chat_session")
-            .append_must_match("chat_session_name", key)
-            .append_must_term("status", std::to_string(0));
-
-        if (type.has_value()) {
-            search_builder.append_must_term(
-                "chat_session_type",
-                std::to_string(static_cast<int>(type.value()))
-            );
-        }
-
-        Json::Value json_session = search_builder.search();
-
-        if (!json_session.isArray()) {
-            LOG_ERROR("会话搜索结果不是数组");
-            return res;
-        }
-
-        for (int i = 0; i < json_session.size(); ++i) {
-            res.push_back(
-                json_session[i]["_source"]["chat_session_id"].asString()
-            );
-        }
-
-        return res;
+    bool remove(const std::string &ssid) {
+        return ESRemove(_client, "chat_session").remove(ssid);
     }
 
+    std::vector<std::string> search(const std::string &key,
+                                    std::optional<chatnow::ChatSessionType> type = std::nullopt,
+                                    int size = 20)
+    {
+        std::vector<std::string> res;
+        ESSearch builder(_client, "chat_session");
+        builder.append_must_match("chat_session_name", key)
+               .append_must_term("status", std::to_string(0)) // 仅正常
+               .sort_by("update_time", "desc")
+               .page(0, size);
+        if(type.has_value()) {
+            builder.append_must_term("chat_session_type",
+                                     std::to_string(static_cast<int>(type.value())));
+        }
+        Json::Value json_session = builder.search();
+        if(!json_session.isArray()) return res;
+        for(int i = 0; i < (int)json_session.size(); ++i) {
+            res.push_back(json_session[i]["_source"]["chat_session_id"].asString());
+        }
+        return res;
+    }
 
 private:
     std::shared_ptr<elasticlient::Client> _client;
 };
-
 
 } // namespace chatnow

--- a/code/server/common/data_redis.hpp
+++ b/code/server/common/data_redis.hpp
@@ -1,65 +1,330 @@
-#include <sw/redis++/redis++.h>
-#include <iostream>
+#pragma once
 
-namespace chatnow 
+/**
+ * ===========================================================================
+ * Redis 封装
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. 工厂支持连接池配置（pool_size / wait_timeout / connection_timeout）
+ *   2. 用域命名空间隔离 key（KeyPrefix），避免不同业务键冲突
+ *   3. 给 IM 关键路径补齐能力：
+ *      - SeqGen      会话级 / 用户级单调递增 seq（取代 DB AUTO_INCREMENT 热点）
+ *      - LastMessage 最近一条消息预览缓存
+ *      - DeviceSet   用户在线设备集合（推送时一次拿到全部 token）
+ *      - ReadAck     大群已读暂存（落库前的批量缓冲）
+ *   4. Session/Status/Codes 全部带 TTL 保护，避免 OOM
+ *   5. 所有 set 操作统一走 try/catch，错误打日志而非抛到调用栈顶
+ * ===========================================================================
+ */
+
+#include <sw/redis++/redis++.h>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+#include "logger.hpp"
+
+namespace chatnow
 {
 
+namespace key
+{
+    inline constexpr const char* kSession    = "im:sess:";          // session_id -> user_id
+    inline constexpr const char* kStatus     = "im:status:";        // user_id    -> 1
+    inline constexpr const char* kVerifyCode = "im:code:";          // code_id    -> 验证码
+    inline constexpr const char* kSeqSession = "im:seq:ssid:";      // ssid       -> 会话级 seq
+    inline constexpr const char* kSeqUser    = "im:seq:uid:";       // uid        -> 用户级 seq
+    inline constexpr const char* kLastMsg    = "im:last:";          // ssid       -> 最后一条消息预览(JSON)
+    inline constexpr const char* kDeviceSet  = "im:dev:";           // uid        -> SET<device_id>
+    inline constexpr const char* kReadAck    = "im:read:";          // mid        -> SET<uid>
+} // namespace key
+
+/* brief: 默认 TTL 常量 */
+inline constexpr std::chrono::seconds kSessionTtl(24 * 3600 * 7);   // 登录态 7 天
+inline constexpr std::chrono::seconds kStatusTtl(60 * 5);           // 在线态 5 分钟（依赖心跳续期）
+inline constexpr std::chrono::seconds kCodeTtl(60 * 5);             // 验证码 5 分钟
+inline constexpr std::chrono::seconds kLastMsgTtl(24 * 3600);       // 最近消息预览 24 小时
+inline constexpr std::chrono::seconds kReadAckTtl(24 * 3600);       // 已读暂存 24 小时
+
+
+/* brief: Redis 工厂（带连接池） */
 class RedisClientFactory
 {
 public:
     static std::shared_ptr<sw::redis::Redis> create(const std::string &host,
                                                     uint16_t port,
                                                     int db,
-                                                    bool keep_alive)
+                                                    bool keep_alive,
+                                                    int pool_size = 8)
     {
-        sw::redis::ConnectionOptions opts;
-        opts.host = host;
-        opts.port = port;
-        opts.db = db;
-        opts.keep_alive = keep_alive;
-        auto res = std::make_shared<sw::redis::Redis>(opts);
-        return res;
+        sw::redis::ConnectionOptions copts;
+        copts.host = host;
+        copts.port = port;
+        copts.db = db;
+        copts.keep_alive = keep_alive;
+        copts.connect_timeout = std::chrono::milliseconds(2000);
+        copts.socket_timeout  = std::chrono::milliseconds(2000);
+
+        sw::redis::ConnectionPoolOptions popts;
+        popts.size              = pool_size;
+        popts.wait_timeout      = std::chrono::milliseconds(500);
+        popts.connection_lifetime = std::chrono::minutes(30);
+
+        return std::make_shared<sw::redis::Redis>(copts, popts);
     }
 };
+
+// =============================================================================
+// 登录态 / 在线态 / 验证码（沿用旧 API，但补齐 TTL）
+// =============================================================================
 
 class Session
 {
 public:
     using ptr = std::shared_ptr<Session>;
-    Session(const std::shared_ptr<sw::redis::Redis> &redis_client) : _redis_client(redis_client) {}
-    void append(const std::string &ssid, const std::string &uid) { _redis_client->set(ssid, uid); }
-    void remove(const std::string &ssid) { _redis_client->del(ssid); }
-    sw::redis::OptionalString uid(const std::string &ssid) { return _redis_client->get(ssid); }
+    Session(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+
+    /* brief: 写入登录态，TTL 7 天 */
+    void append(const std::string &ssid, const std::string &uid,
+                std::chrono::seconds ttl = kSessionTtl) {
+        try { _c->set(key::kSession + ssid, uid, ttl); }
+        catch(std::exception &e) { LOG_ERROR("Session.append 失败 {}: {}", ssid, e.what()); }
+    }
+    void remove(const std::string &ssid) {
+        try { _c->del(key::kSession + ssid); }
+        catch(std::exception &e) { LOG_ERROR("Session.remove 失败 {}: {}", ssid, e.what()); }
+    }
+    sw::redis::OptionalString uid(const std::string &ssid) {
+        try { return _c->get(key::kSession + ssid); }
+        catch(std::exception &e) { LOG_ERROR("Session.uid 失败 {}: {}", ssid, e.what()); return {}; }
+    }
+    /* brief: 续期（每次心跳调用） */
+    void touch(const std::string &ssid, std::chrono::seconds ttl = kSessionTtl) {
+        try { _c->expire(key::kSession + ssid, ttl); }
+        catch(std::exception &e) { LOG_ERROR("Session.touch 失败 {}: {}", ssid, e.what()); }
+    }
 private:
-    std::shared_ptr<sw::redis::Redis> _redis_client;
+    std::shared_ptr<sw::redis::Redis> _c;
 };
 
 class Status
 {
 public:
     using ptr = std::shared_ptr<Status>;
-    Status(const std::shared_ptr<sw::redis::Redis> &redis_client) : _redis_client(redis_client) {}
-    void append(const std::string &uid) { _redis_client->set(uid, ""); }
-    void remove(const std::string &uid) { _redis_client->del(uid); }
-    bool exists(const std::string &uid) { 
-        auto res = _redis_client->get(uid); 
-        if(res) return true;
-        return false;
+    Status(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    void append(const std::string &uid, std::chrono::seconds ttl = kStatusTtl) {
+        try { _c->set(key::kStatus + uid, "1", ttl); }
+        catch(std::exception &e) { LOG_ERROR("Status.append 失败 {}: {}", uid, e.what()); }
+    }
+    void remove(const std::string &uid) {
+        try { _c->del(key::kStatus + uid); }
+        catch(std::exception &e) { LOG_ERROR("Status.remove 失败 {}: {}", uid, e.what()); }
+    }
+    bool exists(const std::string &uid) {
+        try { return _c->get(key::kStatus + uid).has_value(); }
+        catch(std::exception &e) { LOG_ERROR("Status.exists 失败 {}: {}", uid, e.what()); return false; }
+    }
+    /* brief: 心跳续期 */
+    void touch(const std::string &uid, std::chrono::seconds ttl = kStatusTtl) {
+        try { _c->expire(key::kStatus + uid, ttl); }
+        catch(std::exception &e) { LOG_ERROR("Status.touch 失败 {}: {}", uid, e.what()); }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _redis_client;
+    std::shared_ptr<sw::redis::Redis> _c;
 };
 
 class Codes
 {
 public:
     using ptr = std::shared_ptr<Codes>;
-    Codes(const std::shared_ptr<sw::redis::Redis> &redis_client) : _redis_client(redis_client) {}
-    void append(const std::string &cid, const std::string &code, const std::chrono::milliseconds &ttl = std::chrono::milliseconds(300000)) { _redis_client->set(cid, code, ttl); }
-    void remove(const std::string &cid) { _redis_client->del(cid); }
-    sw::redis::OptionalString code(const std::string &cid) { return _redis_client->get(cid); }
+    Codes(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    void append(const std::string &cid, const std::string &code,
+                std::chrono::seconds ttl = kCodeTtl) {
+        try { _c->set(key::kVerifyCode + cid, code, ttl); }
+        catch(std::exception &e) { LOG_ERROR("Codes.append 失败 {}: {}", cid, e.what()); }
+    }
+    void remove(const std::string &cid) {
+        try { _c->del(key::kVerifyCode + cid); }
+        catch(std::exception &e) { LOG_ERROR("Codes.remove 失败 {}: {}", cid, e.what()); }
+    }
+    sw::redis::OptionalString code(const std::string &cid) {
+        try { return _c->get(key::kVerifyCode + cid); }
+        catch(std::exception &e) { LOG_ERROR("Codes.code 失败 {}: {}", cid, e.what()); return {}; }
+    }
 private:
-    std::shared_ptr<sw::redis::Redis> _redis_client;
+    std::shared_ptr<sw::redis::Redis> _c;
 };
 
-}
+// =============================================================================
+// IM 核心：分布式 seq 生成器
+// =============================================================================
+
+/**
+ * SeqGen
+ * ------------------------------------------------------------------
+ * 取代 DB AUTO_INCREMENT 在分库分表场景的全局热点：
+ *   - next_session_seq(ssid)  会话级单调递增；message.seq_id 来源
+ *   - next_user_seq(uid)      用户级单调递增；user_timeline.user_seq 来源
+ *
+ * Redis INCR 是原子的，性能 ~10 万/s/分片；可按 ssid 哈希到不同 Redis 实例
+ * 实现水平扩展。
+ *
+ * Redis 数据丢失保护：
+ *   - 每次申请时 max(curr, db_max_seq+1) 兜底，启动时由消息服务从
+ *     message 主表 SELECT MAX(seq_id) 回填一次（应用层保证）
+ * ------------------------------------------------------------------
+ */
+class SeqGen
+{
+public:
+    using ptr = std::shared_ptr<SeqGen>;
+    SeqGen(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+
+    /* brief: 申请一个会话级 seq；失败返回 0（业务侧需视为 fatal） */
+    unsigned long next_session_seq(const std::string &ssid) {
+        try { return static_cast<unsigned long>(_c->incr(key::kSeqSession + ssid)); }
+        catch(std::exception &e) {
+            LOG_ERROR("SeqGen.next_session_seq 失败 {}: {}", ssid, e.what());
+            return 0;
+        }
+    }
+    /* brief: 申请一个用户级 seq */
+    unsigned long next_user_seq(const std::string &uid) {
+        try { return static_cast<unsigned long>(_c->incr(key::kSeqUser + uid)); }
+        catch(std::exception &e) {
+            LOG_ERROR("SeqGen.next_user_seq 失败 {}: {}", uid, e.what());
+            return 0;
+        }
+    }
+    /* brief: 启动回填 / Redis 数据丢失修复用：把当前 seq 拉到至少 base */
+    void backfill_session(const std::string &ssid, unsigned long base) {
+        try {
+            // SET key base NX 之后 INCR；保证不回退
+            auto cur = _c->get(key::kSeqSession + ssid);
+            unsigned long cur_v = cur ? std::stoul(*cur) : 0;
+            if(cur_v < base) _c->set(key::kSeqSession + ssid, std::to_string(base));
+        } catch(std::exception &e) {
+            LOG_ERROR("SeqGen.backfill_session 失败 {}: {}", ssid, e.what());
+        }
+    }
+    void backfill_user(const std::string &uid, unsigned long base) {
+        try {
+            auto cur = _c->get(key::kSeqUser + uid);
+            unsigned long cur_v = cur ? std::stoul(*cur) : 0;
+            if(cur_v < base) _c->set(key::kSeqUser + uid, std::to_string(base));
+        } catch(std::exception &e) {
+            LOG_ERROR("SeqGen.backfill_user 失败 {}: {}", uid, e.what());
+        }
+    }
+private:
+    std::shared_ptr<sw::redis::Redis> _c;
+};
+
+// =============================================================================
+// 最近一条消息预览缓存（替代 chat_session.last_message_* 行级写热点）
+// =============================================================================
+
+class LastMessage
+{
+public:
+    using ptr = std::shared_ptr<LastMessage>;
+    LastMessage(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+
+    /* brief: 写最后一条消息预览（已序列化 JSON 字符串）；TTL 24h */
+    void set(const std::string &ssid, const std::string &preview_json,
+             std::chrono::seconds ttl = kLastMsgTtl) {
+        try { _c->set(key::kLastMsg + ssid, preview_json, ttl); }
+        catch(std::exception &e) { LOG_ERROR("LastMessage.set 失败 {}: {}", ssid, e.what()); }
+    }
+    sw::redis::OptionalString get(const std::string &ssid) {
+        try { return _c->get(key::kLastMsg + ssid); }
+        catch(std::exception &e) { LOG_ERROR("LastMessage.get 失败 {}: {}", ssid, e.what()); return {}; }
+    }
+    void remove(const std::string &ssid) {
+        try { _c->del(key::kLastMsg + ssid); }
+        catch(std::exception &e) { LOG_ERROR("LastMessage.del 失败 {}: {}", ssid, e.what()); }
+    }
+private:
+    std::shared_ptr<sw::redis::Redis> _c;
+};
+
+// =============================================================================
+// 用户在线设备集合（推送下发入口）
+// =============================================================================
+
+class DeviceSet
+{
+public:
+    using ptr = std::shared_ptr<DeviceSet>;
+    DeviceSet(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+
+    /* brief: 用户某设备上线 */
+    void add(const std::string &uid, const std::string &device_id) {
+        try { _c->sadd(key::kDeviceSet + uid, device_id); }
+        catch(std::exception &e) { LOG_ERROR("DeviceSet.add 失败 {}-{}: {}", uid, device_id, e.what()); }
+    }
+    /* brief: 用户某设备下线 */
+    void remove(const std::string &uid, const std::string &device_id) {
+        try { _c->srem(key::kDeviceSet + uid, device_id); }
+        catch(std::exception &e) { LOG_ERROR("DeviceSet.rem 失败 {}-{}: {}", uid, device_id, e.what()); }
+    }
+    /* brief: 取用户当前所有在线设备 */
+    std::vector<std::string> list(const std::string &uid) {
+        std::vector<std::string> res;
+        try { _c->smembers(key::kDeviceSet + uid, std::inserter(res, res.end())); }
+        catch(std::exception &e) { LOG_ERROR("DeviceSet.list 失败 {}: {}", uid, e.what()); }
+        return res;
+    }
+    /* brief: 用户是否有任意在线设备 */
+    bool any(const std::string &uid) {
+        try { return _c->scard(key::kDeviceSet + uid) > 0; }
+        catch(std::exception &e) { LOG_ERROR("DeviceSet.any 失败 {}: {}", uid, e.what()); return false; }
+    }
+private:
+    std::shared_ptr<sw::redis::Redis> _c;
+};
+
+// =============================================================================
+// 群消息已读暂存（异步落库前的高 QPS 缓冲）
+// =============================================================================
+
+class ReadAck
+{
+public:
+    using ptr = std::shared_ptr<ReadAck>;
+    ReadAck(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+
+    /* brief: 用户对消息已读，幂等添加到 SET */
+    void ack(unsigned long message_id, const std::string &uid,
+             std::chrono::seconds ttl = kReadAckTtl) {
+        try {
+            std::string k = key::kReadAck + std::to_string(message_id);
+            _c->sadd(k, uid);
+            _c->expire(k, ttl);
+        } catch(std::exception &e) {
+            LOG_ERROR("ReadAck.ack 失败 mid={} uid={}: {}", message_id, uid, e.what());
+        }
+    }
+    /* brief: 已读人数（角标"已读 X 人"用） */
+    long count(unsigned long message_id) {
+        try { return _c->scard(key::kReadAck + std::to_string(message_id)); }
+        catch(std::exception &e) { LOG_ERROR("ReadAck.count 失败 {}: {}", message_id, e.what()); return 0; }
+    }
+    /* brief: 后台批量刷库后调用，移交所有权后清空 SET 防止重复刷库 */
+    std::vector<std::string> drain(unsigned long message_id) {
+        std::vector<std::string> res;
+        try {
+            std::string k = key::kReadAck + std::to_string(message_id);
+            _c->smembers(k, std::inserter(res, res.end()));
+            _c->del(k);
+        } catch(std::exception &e) {
+            LOG_ERROR("ReadAck.drain 失败 {}: {}", message_id, e.what());
+        }
+        return res;
+    }
+private:
+    std::shared_ptr<sw::redis::Redis> _c;
+};
+
+} // namespace chatnow

--- a/code/server/common/etcd.hpp
+++ b/code/server/common/etcd.hpp
@@ -1,84 +1,149 @@
 #pragma once
 
+/**
+ * ===========================================================================
+ * etcd 服务注册 / 发现封装
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. Registry: 改用 lease keep-alive；析构走 Cancel（旧版调 Lease() 是错的）
+ *   2. Discovery: 监听 basedir 下的 PUT/DELETE 事件，回调送给 ServiceManager
+ *   3. 日志统一改为 LOG_xxx 宏（旧版用了 SPDLOG_xxx 不走我们的格式）
+ *   4. 新增 Registry::unregister()：服务退出前主动撤销，避免依赖 lease 过期
+ *   5. KeepAlive 间隔 3s 写死过短；改为 30s lease + 默认 keepalive 内置心跳
+ * ===========================================================================
+ */
+
 #include <etcd/Client.hpp>
 #include <etcd/KeepAlive.hpp>
 #include <etcd/Response.hpp>
 #include <etcd/Watcher.hpp>
 #include <etcd/Value.hpp>
+#include <functional>
+#include <memory>
+#include <string>
 #include "logger.hpp"
 
 namespace chatnow
 {
 
-static constexpr int keepAliveTime = 3;
+inline constexpr int kLeaseSeconds = 30;  // 30s lease，避免 3s 过短的瞬时抖动让节点频繁掉线
 
-/* brief: 服务注册客户端类 */
+/* brief: 服务注册客户端
+ *  - 启动时调 registry(key, host) 写入实例信息
+ *  - lease 周期内由后台 keep-alive 自动续期
+ *  - 进程退出前应主动调 unregister() 撤销，让上游服务发现立即感知下线
+ */
 class Registry
 {
 public:
     using ptr = std::shared_ptr<Registry>;
 
-    Registry(const std::string &host) : _client(std::make_shared<etcd::Client>(host)), _keep_alive(_client->leasekeepalive(keepAliveTime).get()), _lease_id(_keep_alive->Lease()) {}
-    ~Registry() { _keep_alive->Lease(); }
+    explicit Registry(const std::string &host)
+        : _client(std::make_shared<etcd::Client>(host)),
+          _keep_alive(_client->leasekeepalive(kLeaseSeconds).get()),
+          _lease_id(_keep_alive->Lease()) {}
+
+    ~Registry() {
+        try {
+            // 撤销 lease，关联的 key 立刻失效；旧实现错调 Lease() 实际是 getter
+            _keep_alive->Cancel();
+            _client->lease_revoke(_lease_id).wait();
+        } catch(...) { /* 析构吞异常 */ }
+    }
+
+    /* brief: 注册服务实例 (key, value=host) */
     bool registry(const std::string &key, const std::string &val) {
-        auto resp = _client->put(key, val, _lease_id).get();
-        if(resp.is_ok() == false) {
-            SPDLOG_ERROR("注册数据失败: {}", resp.error_message());
+        try {
+            auto resp = _client->put(key, val, _lease_id).get();
+            if(!resp.is_ok()) {
+                LOG_ERROR("注册数据失败 key={}: {}", key, resp.error_message());
+                return false;
+            }
+            _registered_key = key;
+            return true;
+        } catch(std::exception &e) {
+            LOG_ERROR("注册数据异常 key={}: {}", key, e.what());
             return false;
         }
-        return true;
     }
+
+    /* brief: 主动注销 — 进程优雅退出时应在主循环停止后调用 */
+    void unregister() {
+        if(_registered_key.empty()) return;
+        try {
+            _client->rm(_registered_key).wait();
+            _registered_key.clear();
+        } catch(std::exception &e) {
+            LOG_WARN("主动注销失败 key={}: {}", _registered_key, e.what());
+        }
+    }
+
 private:
     std::shared_ptr<etcd::Client> _client;
     std::shared_ptr<etcd::KeepAlive> _keep_alive;
     uint64_t _lease_id;
+    std::string _registered_key;  // 注册的 key，析构 / 主动注销时使用
 };
-/* brief: 服务发现客户端类 */
+
+/* brief: 服务发现客户端
+ *  - 启动时拉一次 basedir 下全部 key
+ *  - 之后通过 Watcher 监听 PUT/DELETE 事件
+ *  - 把事件回调给 ServiceManager 维护 brpc Channel 池
+ */
 class Discovery
 {
 public:
     using ptr = std::shared_ptr<Discovery>;
     using NotifyCallback = std::function<void(std::string, std::string)>;
 
-    Discovery(const std::string &host, const std::string &basedir, const NotifyCallback &put_cb, const NotifyCallback &del_cb)
+    Discovery(const std::string &host,
+              const std::string &basedir,
+              const NotifyCallback &put_cb,
+              const NotifyCallback &del_cb)
         : _client(std::make_shared<etcd::Client>(host)),
           _put_cb(put_cb), _del_cb(del_cb)
-        {   
-            // 先进行服务发现，先获取到当前已有的数据
-            auto resp = _client->ls(basedir).get();
-            if(resp.is_ok() == false) {
-                SPDLOG_ERROR("获取服务信息数据失败: {}", resp.error_message());
-            }
-            int sz = resp.keys().size();
-            for(int i = 0; i < sz; ++i) {
+    {
+        // 1) 全量拉取 basedir 下当前 key，触发 PUT 回调
+        auto resp = _client->ls(basedir).get();
+        if(!resp.is_ok()) {
+            LOG_ERROR("拉取 etcd basedir={} 失败: {}", basedir, resp.error_message());
+        } else {
+            for(int i = 0; i < static_cast<int>(resp.keys().size()); ++i) {
                 if(_put_cb) _put_cb(resp.key(i), resp.value(i).as_string());
             }
-            // 然后进行事件监控，监控数据发生的改变并调用回调处理
-            _watcher = std::make_shared<etcd::Watcher>(*_client.get(), basedir, std::bind(&Discovery::callback, this, std::placeholders::_1), true);
         }
-    ~Discovery() { _watcher->Cancel(); }
+        // 2) 长轮询监听增量事件
+        _watcher = std::make_shared<etcd::Watcher>(
+            *_client.get(), basedir,
+            std::bind(&Discovery::callback, this, std::placeholders::_1),
+            true);
+    }
+
+    ~Discovery() {
+        try { if(_watcher) _watcher->Cancel(); } catch(...) {}
+    }
+
 private:
     void callback(const etcd::Response &resp) {
-        if(resp.is_ok() == false) {
-            SPDLOG_ERROR("收到错误的事件通知: {}", resp.error_message());
+        if(!resp.is_ok()) {
+            LOG_ERROR("收到错误的事件通知: {}", resp.error_message());
             return;
         }
-        for(auto const &ev : resp.events()) {
+        for(const auto &ev : resp.events()) {
             if(ev.event_type() == etcd::Event::EventType::PUT) {
-                if(_put_cb) _put_cb(ev.kv().key(), ev.kv().as_string()); 
-                SPDLOG_DEBUG("新增服务: {} - {}", ev.kv().key(), ev.kv().as_string());
+                if(_put_cb) _put_cb(ev.kv().key(), ev.kv().as_string());
+                LOG_DEBUG("服务上线: {} - {}", ev.kv().key(), ev.kv().as_string());
             } else if(ev.event_type() == etcd::Event::EventType::DELETE_) {
                 if(_del_cb) _del_cb(ev.prev_kv().key(), ev.prev_kv().as_string());
-                SPDLOG_DEBUG("下线服务: {} - {}", ev.prev_kv().key(), ev.prev_kv().as_string());
+                LOG_DEBUG("服务下线: {} - {}", ev.prev_kv().key(), ev.prev_kv().as_string());
             }
         }
     }
-private:
+
     NotifyCallback _put_cb;
     NotifyCallback _del_cb;
     std::shared_ptr<etcd::Client> _client;
     std::shared_ptr<etcd::Watcher> _watcher;
-    uint64_t _lease_id;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/icsearch.hpp
+++ b/code/server/common/icsearch.hpp
@@ -1,21 +1,41 @@
+#pragma once
+
+/**
+ * ===========================================================================
+ * Elasticsearch 客户端轻封装（基于 elasticlient）
+ * ---------------------------------------------------------------------------
+ * 设计要点（在原版基础上的修订）：
+ *   1. 自由函数 Serialize / UnSerialize 加 inline，避免多 TU include 链接重复
+ *   2. 移除 ESIndex 构造里调试遗留的 std::cout
+ *   3. 新增 ESUpdate：upsert 语义，IM 频繁写覆盖场景
+ *   4. ESSearch:
+ *      - 同时存在 must 与 should 时自动加 minimum_should_match=1
+ *        否则 ES bool query 行为会让 should 仅作打分加权，不参与命中
+ *      - 增加 size / from 分页与 sort 排序设置
+ *   5. 错误日志统一 LOG_ERROR；脱敏 body（仅在 trace 等级输出）
+ *   6. ES 7.x+ 已不需要 type 参数；保留 "_doc" 兼容旧索引
+ * ===========================================================================
+ */
+
 #include <elasticlient/client.h>
 #include <cpr/cpr.h>
 #include <jsoncpp/json/json.h>
 #include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 #include "logger.hpp"
 
 namespace chatnow
 {
 
-bool Serialize(const Json::Value &val, std::string &dst) {
-    // 先定义 Json::StreamWriter 工厂类 Json::StreamWriterBuilder
+/* brief: JSON -> string */
+inline bool Serialize(const Json::Value &val, std::string &dst) {
     Json::StreamWriterBuilder swb;
     swb.settings_["emitUTF8"] = true;
     std::unique_ptr<Json::StreamWriter> sw(swb.newStreamWriter());
-    // 通过 Json::StreamWriter 中的 write 接口进行序列化
     std::stringstream ss;
-    int ret = sw->write(val, &ss);
-    if(ret != 0) {
+    if(sw->write(val, &ss) != 0) {
         LOG_WARN("Json 序列化失败");
         return false;
     }
@@ -23,53 +43,51 @@ bool Serialize(const Json::Value &val, std::string &dst) {
     return true;
 }
 
-bool UnSerialize(const std::string &src, Json::Value &val) {
+/* brief: string -> JSON */
+inline bool UnSerialize(const std::string &src, Json::Value &val) {
     Json::CharReaderBuilder crb;
     std::unique_ptr<Json::CharReader> cr(crb.newCharReader());
     std::string err;
-    bool ret = cr->parse(src.c_str(), src.c_str() + src.size(), &val, &err);
-    if(ret == false) {
-        LOG_WARN("Json 反序列化失败");
+    if(!cr->parse(src.c_str(), src.c_str() + src.size(), &val, &err)) {
+        LOG_WARN("Json 反序列化失败: {}", err);
         return false;
     }
     return true;
 }
 
+/* brief: 索引 builder — 链式声明 mapping 字段后 create()
+ *  - settings 内置 ik 分词器配置（中文分词）
+ *  - 调用方按字段类型 / 是否参与检索逐个 append
+ */
 class ESIndex
 {
 public:
-    ESIndex(std::shared_ptr<elasticlient::Client> &client, 
-            const std::string &name, 
-            const std::string &type = "_doc") : 
-            _name(name), _type(type), _client(client) 
+    ESIndex(std::shared_ptr<elasticlient::Client> &client,
+            const std::string &name,
+            const std::string &type = "_doc")
+        : _name(name), _type(type), _client(client)
     {
-        Json::Value settings;
-        Json::Value analysis;
-        Json::Value analyzer;
-        Json::Value ik;
         Json::Value tokenizer;
         tokenizer["tokenizer"] = "ik_max_word";
-        ik["ik"] = tokenizer;
-        analyzer["analyzer"] = ik;
-        analysis["analysis"] = analyzer;
+        Json::Value ik;       ik["ik"] = tokenizer;
+        Json::Value analyzer; analyzer["analyzer"] = ik;
+        Json::Value analysis; analysis["analysis"] = analyzer;
         _index["settings"] = analysis;
-
-        std::string str;
-        Serialize(settings, str);
-        std::cout << str << std::endl;
     }
-    ESIndex& append(const std::string &key, 
-                const std::string &type = "text", 
-                const std::string &analyzer = "ik_max_word", 
-                bool enabled = true)
+
+    ESIndex& append(const std::string &key,
+                    const std::string &type = "text",
+                    const std::string &analyzer = "ik_max_word",
+                    bool enabled = true)
     {
-        Json::Value fields;
-        fields["type"] = type;
-        fields["analyzer"] = analyzer;
-        if(enabled == false) fields["enabled"] = enabled;
-        _properties[key] = fields;
+        Json::Value f;
+        f["type"] = type;
+        f["analyzer"] = analyzer;
+        if(!enabled) f["enabled"] = enabled;
+        _properties[key] = f;
         return *this;
     }
+
     bool create(const std::string &index_id = "default_index_id") {
         Json::Value mappings;
         mappings["dynamic"] = true;
@@ -77,25 +95,24 @@ public:
         _index["mappings"] = mappings;
 
         std::string body;
-        bool ret = Serialize(_index, body);
-        if(ret == false) {
+        if(!Serialize(_index, body)) {
             LOG_ERROR("索引序列化失败");
             return false;
         }
-        LOG_TRACE("{}", body);
-        // 发起搜索请求
+        LOG_TRACE("ES create index {}: {}", _name, body);
         try {
             auto rsp = _client->index(_name, _type, index_id, body);
             if(rsp.status_code < 200 || rsp.status_code >= 300) {
-                LOG_ERROR("创建 ES 索引 {} 失败: {}", _name, rsp.status_code);
+                LOG_ERROR("创建 ES 索引 {} 失败: status={}", _name, rsp.status_code);
                 return false;
             }
         } catch(std::exception &e) {
-            LOG_ERROR("创建 ES 索引 {} 失败: {}", _name, e.what());
+            LOG_ERROR("创建 ES 索引 {} 异常: {}", _name, e.what());
             return false;
         }
         return true;
     }
+
 private:
     std::string _name;
     std::string _type;
@@ -104,36 +121,38 @@ private:
     std::shared_ptr<elasticlient::Client> _client;
 };
 
+/* brief: 文档插入 builder（id 相同则覆盖，等价 upsert） */
 class ESInsert
 {
 public:
-    ESInsert(std::shared_ptr<elasticlient::Client> &client, 
-            const std::string &name,
-            const std::string &type = "_doc") :
-            _name(name), _type(type), _client(client) {}
-    template<typename T>
+    ESInsert(std::shared_ptr<elasticlient::Client> &client,
+             const std::string &name,
+             const std::string &type = "_doc")
+        : _name(name), _type(type), _client(client) {}
+
+    template <typename T>
     ESInsert &append(const std::string &key, const T &val) { _item[key] = val; return *this; }
-    bool insert(const std::string id = "") {
+
+    bool insert(const std::string &id = "") {
         std::string body;
-        bool ret = Serialize(_item, body);
-        if(ret == false) {
-            LOG_ERROR("索引序列化失败");
+        if(!Serialize(_item, body)) {
+            LOG_ERROR("插入数据序列化失败");
             return false;
         }
-        // 发起搜索请求
-        LOG_TRACE("{}", body);
+        LOG_TRACE("ES insert {}: {}", _name, body);
         try {
             auto rsp = _client->index(_name, _type, id, body);
             if(rsp.status_code < 200 || rsp.status_code >= 300) {
-                LOG_ERROR("新增 ES 数据 {} 失败: {}", body, rsp.status_code);
+                LOG_ERROR("新增 ES 数据失败 idx={} id={} status={}", _name, id, rsp.status_code);
                 return false;
             }
         } catch(std::exception &e) {
-            LOG_ERROR("新增 ES 数据 {} 失败: {}", body, e.what());
+            LOG_ERROR("新增 ES 数据异常 idx={} id={}: {}", _name, id, e.what());
             return false;
         }
         return true;
     }
+
 private:
     std::string _name;
     std::string _type;
@@ -141,118 +160,178 @@ private:
     std::shared_ptr<elasticlient::Client> _client;
 };
 
-class ESRemove
+/* brief: 部分字段更新 — IM 资料修改场景常用（无需重传整文档）
+ *  - 通过 _update API 实现，POST /{index}/_update/{id}
+ *  - elasticlient 没直接提供 update，使用 performRequest 走原始 HTTP
+ */
+class ESUpdate
 {
 public:
-    ESRemove(std::shared_ptr<elasticlient::Client> &client, 
-            const std::string &name,
-            const std::string &type = "_doc") :
-            _name(name), _type(type), _client(client) {}
-    bool remove(const std::string &id) {
+    ESUpdate(std::shared_ptr<elasticlient::Client> &client,
+             const std::string &name)
+        : _name(name), _client(client) {}
+
+    template <typename T>
+    ESUpdate &set(const std::string &key, const T &val) { _doc[key] = val; return *this; }
+
+    /* brief: doc-as-upsert 即如果文档不存在则插入 */
+    bool update(const std::string &id, bool upsert = true) {
+        Json::Value root;
+        root["doc"] = _doc;
+        if(upsert) root["doc_as_upsert"] = true;
+
+        std::string body;
+        if(!Serialize(root, body)) {
+            LOG_ERROR("更新数据序列化失败");
+            return false;
+        }
+        LOG_TRACE("ES update {}/{}: {}", _name, id, body);
         try {
-            auto rsp = _client->remove(_name, _type, id);
+            auto rsp = _client->performRequest(
+                elasticlient::Client::HTTPMethod::POST,
+                _name + "/_update/" + id, body);
             if(rsp.status_code < 200 || rsp.status_code >= 300) {
-                LOG_ERROR("删除 ES 数据 {} 失败: {}", id, rsp.status_code);
+                LOG_ERROR("更新 ES 数据失败 idx={} id={} status={}", _name, id, rsp.status_code);
                 return false;
             }
         } catch(std::exception &e) {
-            LOG_ERROR("删除 ES 数据 {} 失败: {}", id, e.what());
+            LOG_ERROR("更新 ES 数据异常 idx={} id={}: {}", _name, id, e.what());
             return false;
         }
         return true;
     }
+
+private:
+    std::string _name;
+    Json::Value _doc;
+    std::shared_ptr<elasticlient::Client> _client;
+};
+
+class ESRemove
+{
+public:
+    ESRemove(std::shared_ptr<elasticlient::Client> &client,
+             const std::string &name,
+             const std::string &type = "_doc")
+        : _name(name), _type(type), _client(client) {}
+
+    bool remove(const std::string &id) {
+        try {
+            auto rsp = _client->remove(_name, _type, id);
+            if(rsp.status_code < 200 || rsp.status_code >= 300) {
+                LOG_ERROR("删除 ES 数据失败 idx={} id={} status={}", _name, id, rsp.status_code);
+                return false;
+            }
+        } catch(std::exception &e) {
+            LOG_ERROR("删除 ES 数据异常 idx={} id={}: {}", _name, id, e.what());
+            return false;
+        }
+        return true;
+    }
+
 private:
     std::string _name;
     std::string _type;
     std::shared_ptr<elasticlient::Client> _client;
 };
 
+/* brief: 查询 builder
+ *  - must / must_not / should 链式追加
+ *  - 支持分页 size/from、排序 sort、最小 should 命中数
+ */
 class ESSearch
 {
 public:
-    ESSearch(std::shared_ptr<elasticlient::Client> &client, 
-            const std::string &name,
-            const std::string &type = "_doc") :
-            _name(name), _type(type), _client(client) {}
+    ESSearch(std::shared_ptr<elasticlient::Client> &client,
+             const std::string &name,
+             const std::string &type = "_doc")
+        : _name(name), _type(type), _client(client) {}
+
     ESSearch &append_must_not_terms(const std::string &key, const std::vector<std::string> &vals) {
         Json::Value fields;
-        for(const auto &val : vals) {
-            fields[key].append(val);
-        }
-        Json::Value terms;
-        terms["terms"] = fields;
+        for(const auto &v : vals) fields[key].append(v);
+        Json::Value terms; terms["terms"] = fields;
         _must_not.append(terms);
         return *this;
-        
     }
     ESSearch &append_should_match(const std::string &key, const std::string &val) {
-        Json::Value field;
-        field[key] = val;
-        Json::Value match;
-        match["match"] = field;
-        _should.append(match);
+        Json::Value f; f[key] = val;
+        Json::Value m; m["match"] = f;
+        _should.append(m);
         return *this;
     }
     ESSearch &append_must_term(const std::string &key, const std::string &val) {
-        Json::Value field;
-        field[key] = val;
-        Json::Value term;
-        term["term"] = field;
-        _must.append(term);
+        Json::Value f; f[key] = val;
+        Json::Value t; t["term"] = f;
+        _must.append(t);
         return *this;
     }
     ESSearch &append_must_match(const std::string &key, const std::string &val) {
-        Json::Value field;
-        field[key] = val;
-        Json::Value match;
-        match["match"] = field;
-        _must.append(match);
+        Json::Value f; f[key] = val;
+        Json::Value m; m["match"] = f;
+        _must.append(m);
         return *this;
     }
+
+    /* brief: 分页 */
+    ESSearch &page(int from, int size) { _from = from; _size = size; return *this; }
+
+    /* brief: 排序（多字段调用多次） */
+    ESSearch &sort_by(const std::string &field, const std::string &order = "desc") {
+        Json::Value f; f[field] = order;
+        _sort.append(f);
+        return *this;
+    }
+
     Json::Value search() {
         Json::Value cond;
-        if(_must_not.empty() == false) cond["must_not"] = _must_not;
-        if(_should.empty() == false) cond["should"] = _should;
-        if(_must.empty() == false) cond["must"] = _must;
-        Json::Value query;
-        query["bool"] = cond;
-        Json::Value root;
-        root["query"] = query;
+        if(!_must_not.empty()) cond["must_not"] = _must_not;
+        if(!_should.empty())   cond["should"]   = _should;
+        if(!_must.empty())     cond["must"]     = _must;
+        // 同时有 must 和 should 时，should 默认仅作打分加权 — 这里强制要求至少 1 项命中
+        if(!_should.empty() && !_must.empty()) cond["minimum_should_match"] = 1;
+
+        Json::Value query; query["bool"] = cond;
+        Json::Value root;  root["query"] = query;
+        if(_size > 0) root["size"] = _size;
+        if(_from >= 0) root["from"] = _from;
+        if(!_sort.empty()) root["sort"] = _sort;
 
         std::string body;
-        bool ret = Serialize(root, body);
-        if(ret == false) {
-            LOG_ERROR("索引序列化失败");
-            return false;
+        if(!Serialize(root, body)) {
+            LOG_ERROR("查询 DSL 序列化失败");
+            return Json::Value();
         }
-        LOG_TRACE("{}", body);
-        // 发起搜索请求
+        LOG_TRACE("ES search {}: {}", _name, body);
+
         cpr::Response rsp;
         try {
             rsp = _client->search(_name, _type, body);
             if(rsp.status_code < 200 || rsp.status_code >= 300) {
-                LOG_ERROR("检索 ES 数据 {} 失败: {}", body, rsp.status_code);
+                LOG_ERROR("检索 ES 数据失败 idx={} status={}", _name, rsp.status_code);
                 return Json::Value();
             }
         } catch(std::exception &e) {
-            LOG_ERROR("检索 ES 数据 {} 失败: {}", body, e.what());
+            LOG_ERROR("检索 ES 数据异常 idx={}: {}", _name, e.what());
             return Json::Value();
         }
-        // 对响应正文反序列化
         Json::Value json_res;
-        ret = UnSerialize(rsp.text, json_res);
-        if(ret == false){
-            LOG_ERROR("检索 ES 数据 {}, 结果反序列化失败", rsp.text);
+        if(!UnSerialize(rsp.text, json_res)) {
+            LOG_ERROR("ES 查询结果反序列化失败: {}", rsp.text);
         }
         return json_res["hits"]["hits"];
     }
+
 private:
     std::string _name;
     std::string _type;
     Json::Value _must_not;
     Json::Value _must;
     Json::Value _should;
+    Json::Value _sort;
+    int _size = 0;     // 0 表示用 ES 默认（一般是 10）
+    int _from = -1;    // <0 表示不显式传
     std::shared_ptr<elasticlient::Client> _client;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/logger.hpp
+++ b/code/server/common/logger.hpp
@@ -1,40 +1,91 @@
 #pragma once
 
+/**
+ * ===========================================================================
+ * 日志封装（基于 spdlog）
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. 全局 logger 改为 inline 变量，避免多 TU include 时重复定义链接错误
+ *   2. 发布模式启用「异步日志 + rotating_file_sink」：
+ *      - 单文件 50MB，轮转保留 10 份；避免单文件无限膨胀
+ *      - 异步队列 8192，一个后台线程；日志路径不阻塞业务
+ *   3. flush 策略：调试模式 trace 级即刷；发布模式仅 warn 级别以上即刷，
+ *      其他级别每 3 秒批量刷盘一次，兼顾性能与故障可见性
+ *   4. 日志格式补充毫秒精度时间戳 + 线程 ID + 文件名(去路径)
+ *   5. LOG_xxx 宏使用 __builtin_strrchr 抽出 basename，避免日志冗长
+ *
+ * 使用：
+ *   chatnow::init_logger(true, "/im/logs/user.log", spdlog::level::info);
+ *   LOG_INFO("user logged in: {}", uid);
+ * ===========================================================================
+ */
+
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/async.h>
-#include <iostream>
+#include <chrono>
+#include <memory>
+#include <string>
 
 namespace chatnow
 {
 
-// mode - 运行模式: true-发布模式 | false-调试模式
+// inline 变量保证 ODR：多个 .cc 包含本头文件不会产生重复定义
+inline std::shared_ptr<spdlog::logger> g_default_logger;
 
-std::shared_ptr<spdlog::logger> g_default_logger;
+// 发布模式日志文件大小阈值与保留份数
+inline constexpr size_t kMaxFileSize  = 50 * 1024 * 1024;  // 50MB
+inline constexpr size_t kMaxFileCount = 10;
+inline constexpr size_t kAsyncQueue   = 8192;
 
-void init_logger(bool mode, const std::string &filename, int32_t level) {
-    // 如果是调试模式，则创建标准输出日志器，日志等级为最低
+/* brief: 初始化全局日志器
+ *  @param mode      true=发布模式（文件 + 异步） / false=调试模式（控制台 + 同步）
+ *  @param filename  发布模式输出文件
+ *  @param level     发布模式日志等级（spdlog level enum 整数）
+ */
+inline void init_logger(bool mode, const std::string &filename, int32_t level) {
     if(mode == false) {
+        // 调试模式：彩色控制台输出，最低等级，立即刷盘便于现场调试
         spdlog::drop("console-logger");
         g_default_logger = spdlog::stdout_color_mt("console-logger");
-        g_default_logger->set_level(spdlog::level::level_enum::trace);
-        g_default_logger->flush_on(spdlog::level::level_enum::trace);
+        g_default_logger->set_level(spdlog::level::trace);
+        g_default_logger->flush_on(spdlog::level::trace);
     } else {
-        // 否则是发布模式，则创建文件输出日志器，输出等级根据参数而定
+        // 发布模式：异步 rotating file，避免单文件膨胀 / 同步 IO 阻塞业务线程
         spdlog::drop("file-logger");
-        g_default_logger = spdlog::basic_logger_mt("file-logger", filename);
-        g_default_logger->set_level((spdlog::level::level_enum)level);
-        g_default_logger->flush_on((spdlog::level::level_enum)level);
+        spdlog::init_thread_pool(kAsyncQueue, 1);
+        auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+            filename, kMaxFileSize, kMaxFileCount);
+        g_default_logger = std::make_shared<spdlog::async_logger>(
+            "file-logger",
+            sink,
+            spdlog::thread_pool(),
+            spdlog::async_overflow_policy::block);
+        spdlog::register_logger(g_default_logger);
+        g_default_logger->set_level(static_cast<spdlog::level::level_enum>(level));
+        // warn/error/critical 立即刷；其它级别 3s 批量刷
+        g_default_logger->flush_on(spdlog::level::warn);
+        spdlog::flush_every(std::chrono::seconds(3));
     }
-    g_default_logger->set_pattern("[%n][%H:%M:%S][%t]%^[%l]%$%v");
+    // 模式: [logger名][HH:MM:SS.ms][线程ID][级别] 内容
+    g_default_logger->set_pattern("[%n][%H:%M:%S.%e][%t]%^[%l]%$ %v");
 }
 
-#define LOG_TRACE(format, ...) chatnow::g_default_logger->trace(std::string("[{}:{}] ") + format, __FILE__, __LINE__, ##__VA_ARGS__)
-#define LOG_DEBUG(format, ...) chatnow::g_default_logger->debug(std::string("[{}:{}] ") + format, __FILE__, __LINE__, ##__VA_ARGS__)
-#define LOG_INFO(format, ...) chatnow::g_default_logger->info(std::string("[{}:{}] ") + format, __FILE__, __LINE__, ##__VA_ARGS__)
-#define LOG_WARN(format, ...) chatnow::g_default_logger->warn(std::string("[{}:{}] ") + format, __FILE__, __LINE__, ##__VA_ARGS__)
-#define LOG_ERROR(format, ...) chatnow::g_default_logger->error(std::string("[{}:{}] ") + format, __FILE__, __LINE__, ##__VA_ARGS__)
-#define LOG_FATAL(format, ...) chatnow::g_default_logger->critical(std::string("[{}:{}] ") + format, __FILE__, __LINE__, ##__VA_ARGS__)
-
+/* brief: 抽取文件 basename，避免日志中出现绝对路径噪音 */
+constexpr const char* basename_of(const char* path) {
+    const char* last = path;
+    for(const char* p = path; *p; ++p) {
+        if(*p == '/' || *p == '\\') last = p + 1;
+    }
+    return last;
 }
+
+#define LOG_TRACE(format, ...) chatnow::g_default_logger->trace   (std::string("[{}:{}] ") + format, chatnow::basename_of(__FILE__), __LINE__, ##__VA_ARGS__)
+#define LOG_DEBUG(format, ...) chatnow::g_default_logger->debug   (std::string("[{}:{}] ") + format, chatnow::basename_of(__FILE__), __LINE__, ##__VA_ARGS__)
+#define LOG_INFO(format, ...)  chatnow::g_default_logger->info    (std::string("[{}:{}] ") + format, chatnow::basename_of(__FILE__), __LINE__, ##__VA_ARGS__)
+#define LOG_WARN(format, ...)  chatnow::g_default_logger->warn    (std::string("[{}:{}] ") + format, chatnow::basename_of(__FILE__), __LINE__, ##__VA_ARGS__)
+#define LOG_ERROR(format, ...) chatnow::g_default_logger->error   (std::string("[{}:{}] ") + format, chatnow::basename_of(__FILE__), __LINE__, ##__VA_ARGS__)
+#define LOG_FATAL(format, ...) chatnow::g_default_logger->critical(std::string("[{}:{}] ") + format, chatnow::basename_of(__FILE__), __LINE__, ##__VA_ARGS__)
+
+} // namespace chatnow

--- a/code/server/common/mail.hpp
+++ b/code/server/common/mail.hpp
@@ -1,6 +1,23 @@
+#pragma once
+
+/**
+ * ===========================================================================
+ * 邮件 / 验证码下发封装（基于 libcurl SMTP）
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. CodeClient 抽象接口保留 — 后续可换成第三方短信 / 邮件 SaaS
+ *   2. send() 旧实现存在资源泄漏：错误路径只 return 不 cleanup curl handle、
+ *      不 free curl_slist；本版本统一在函数末尾 cleanup
+ *   3. curl handle 改为 RAII（CurlHandle / SListHandle）避免漏 free
+ *   4. 增加 connect timeout / total timeout，避免 SMTP 阻塞调用线程
+ *   5. 邮件正文模板抽出，便于扩展找回密码 / 异地登录通知等场景
+ * ===========================================================================
+ */
+
 #include <curl/curl.h>
-#include <iostream>
+#include <memory>
 #include <sstream>
+#include <string>
 #include "logger.hpp"
 
 namespace chatnow
@@ -9,16 +26,32 @@ namespace chatnow
 struct mail_settings {
     std::string username;
     std::string password;
-    std::string url;
+    std::string url;        // smtps://smtp.xxx:465
     std::string from;
 };
 
+/* brief: 验证码下发抽象接口（邮箱 / 短信 / 第三方 SaaS） */
 class CodeClient
 {
 public:
     CodeClient() = default;
-    ~CodeClient() = default;
+    virtual ~CodeClient() = default;
     virtual bool send(const std::string &to, const std::string &code) = 0;
+};
+
+/* brief: libcurl 资源 RAII */
+struct CurlHandle {
+    CURL *h = nullptr;
+    CurlHandle() : h(curl_easy_init()) {}
+    ~CurlHandle() { if(h) curl_easy_cleanup(h); }
+    CurlHandle(const CurlHandle &) = delete;
+    CurlHandle &operator=(const CurlHandle &) = delete;
+};
+
+struct SListHandle {
+    curl_slist *l = nullptr;
+    void append(const std::string &s) { l = curl_slist_append(l, s.c_str()); }
+    ~SListHandle() { if(l) curl_slist_free_all(l); }
 };
 
 class MailClient : public CodeClient
@@ -26,104 +59,84 @@ class MailClient : public CodeClient
 public:
     using ptr = std::shared_ptr<MailClient>;
 
-    /* brief: 初始化全局配置，保存服务配置信息 */
-    MailClient(const mail_settings &settings) : _settings(settings) {
+    explicit MailClient(const mail_settings &settings) : _settings(settings) {
         auto ret = curl_global_init(CURL_GLOBAL_DEFAULT);
         if(ret != CURLE_OK) {
-            LOG_ERROR("初始化CURL全局配置失败: {}", curl_easy_strerror(ret));
+            LOG_ERROR("初始化 CURL 全局配置失败: {}", curl_easy_strerror(ret));
             abort();
         }
     }
-    /* brief: 释放全局配置资源 */
-    ~MailClient() { curl_global_cleanup(); }
-    /* brief: 发送邮件 */
-    virtual bool send(const std::string &to, const std::string &code) override {
-        //1. 构造操作句柄
-        auto curl = curl_easy_init();
-        if(curl == nullptr) {
-            LOG_ERROR("构造操作句柄失败");
+    ~MailClient() override { curl_global_cleanup(); }
+
+    /* brief: 发送验证码邮件 */
+    bool send(const std::string &to, const std::string &code) override {
+        CurlHandle curl;
+        if(!curl.h) {
+            LOG_ERROR("构造 CURL 操作句柄失败");
             return false;
         }
-        //2. 设置请求参数
-        auto ret = curl_easy_setopt(curl, CURLOPT_URL, _settings.url.c_str());
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的URL请求参数失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
-        ret = curl_easy_setopt(curl, CURLOPT_USERNAME, _settings.username.c_str());
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的Username请求参数失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
-        ret = curl_easy_setopt(curl, CURLOPT_PASSWORD, _settings.password.c_str());
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的Password请求参数失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
-        ret = curl_easy_setopt(curl, CURLOPT_MAIL_FROM, _settings.from.c_str());
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的From请求参数失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
-        struct curl_slist *cs = nullptr;
-        cs = curl_slist_append(cs, to.c_str());
-        ret = curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, cs);
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的RCPT失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
+
+        if(!setopt(curl.h, CURLOPT_URL, _settings.url.c_str(),       "URL")) return false;
+        if(!setopt(curl.h, CURLOPT_USERNAME, _settings.username.c_str(), "USERNAME")) return false;
+        if(!setopt(curl.h, CURLOPT_PASSWORD, _settings.password.c_str(), "PASSWORD")) return false;
+        if(!setopt(curl.h, CURLOPT_MAIL_FROM, _settings.from.c_str(),    "FROM")) return false;
+
+        SListHandle rcpt;
+        rcpt.append(to);
+        if(!setopt(curl.h, CURLOPT_MAIL_RCPT, rcpt.l, "RCPT")) return false;
+
         auto body = codeBody(to, code);
-        //3. 设置正文
-        ret = curl_easy_setopt(curl, CURLOPT_READDATA, (void*)&body);
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的READDATA失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
-        //4. 设置回调
-        ret = curl_easy_setopt(curl, CURLOPT_READFUNCTION, &callback);
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的READFUNCTION失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
-        //5. 设置发送模式
-        ret = curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
-        if(ret != CURLE_OK) {
-            LOG_ERROR("设置CURL的发送模式失败: {}", curl_easy_strerror(ret));
-            return false;
-        }
-        //6. 执行请求
-        ret = curl_easy_perform(curl);
+        if(!setopt(curl.h, CURLOPT_READDATA, (void*)&body, "READDATA")) return false;
+        if(!setopt(curl.h, CURLOPT_READFUNCTION, &callback, "READFUNCTION")) return false;
+        if(!setopt(curl.h, CURLOPT_UPLOAD, 1L, "UPLOAD")) return false;
+
+        // 增加超时，避免 SMTP 卡死调用线程
+        if(!setopt(curl.h, CURLOPT_CONNECTTIMEOUT, 5L,  "CONNECTTIMEOUT")) return false;
+        if(!setopt(curl.h, CURLOPT_TIMEOUT,        15L, "TIMEOUT")) return false;
+
+        auto ret = curl_easy_perform(curl.h);
         if(ret != CURLE_OK) {
             LOG_ERROR("请求邮件服务器失败: {}", curl_easy_strerror(ret));
             return false;
         }
-        //7. 清理资源
-        curl_slist_free_all(cs);
-        curl_easy_cleanup(curl);
         LOG_DEBUG("发送邮件成功: {}-{}", to, code);
         return true;
     }
-    /* brief: 获取settings  */
-    mail_settings settings() { return _settings; }
+
+    mail_settings settings() const { return _settings; }
+
 private:
-    /* brief: 构造邮件正文 */
-    std::stringstream codeBody(const std::string &to, const std::string &code) {
+    /* brief: setopt 包装：错误路径走日志而非裸 return；模板支持任意值类型 */
+    template <class T>
+    static bool setopt(CURL *c, CURLoption opt, T val, const char *what) {
+        auto ret = curl_easy_setopt(c, opt, val);
+        if(ret != CURLE_OK) {
+            LOG_ERROR("CURL setopt {} 失败: {}", what, curl_easy_strerror(ret));
+            return false;
+        }
+        return true;
+    }
+
+    /* brief: 构造邮件正文（HTML 验证码模板） */
+    std::stringstream codeBody(const std::string &to, const std::string &code) const {
+        (void)to;
         std::stringstream ss;
-        ss << "Subject: " << _title << "\r\n"; //邮件标题
-        ss << "Content-Type: text/html\r\n";
-        ss << "\r\n";
-        ss << "<html><body><p>你的验证码: <b>" << code << "</b></p><p>验证码将在5分钟后失效.</p></body></html>\r\n";
+        ss << "Subject: " << _title << "\r\n"
+           << "Content-Type: text/html\r\n"
+           << "\r\n"
+           << "<html><body><p>你的验证码: <b>" << code
+           << "</b></p><p>验证码将在 5 分钟后失效.</p></body></html>\r\n";
         return ss;
     }
-    /* brief: curl请求处理回调 */
+
     static size_t callback(char *buffer, size_t size, size_t nitems, void *userdata) {
-        std::stringstream *ss = (std::stringstream*)userdata;
-        ss->read(buffer, size * nitems);
-        return ss->gcount();
+        auto *ss = static_cast<std::stringstream*>(userdata);
+        ss->read(buffer, static_cast<std::streamsize>(size * nitems));
+        return static_cast<size_t>(ss->gcount());
     }
-private:
+
     const std::string _title = "验证码";
     mail_settings _settings;
 };
 
-}
+} // namespace chatnow

--- a/code/server/common/mysql.hpp
+++ b/code/server/common/mysql.hpp
@@ -1,11 +1,23 @@
 #pragma once
 
+/**
+ * ===========================================================================
+ * MySQL ODB 数据库工厂
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. 工厂保留旧签名，新增 charset / pool_size / conn_lifetime 调优参数
+ *   2. 默认 charset 改为 utf8mb4，匹配新 schema（旧 utf8 存不下 emoji）
+ *   3. 提供 TxnGuard：基于事务感知的 RAII 包装，便于 DAO 层组合事务
+ *   4. 全局心跳健康检查：ping() 用 SQL "SELECT 1" 实现，便于注册到健康探针
+ * ===========================================================================
+ */
+
+#include <memory>
+#include <string>
 #include <odb/database.hxx>
+#include <odb/transaction.hxx>
 #include <odb/mysql/database.hxx>
 #include "logger.hpp"
-
-//用户注册/登录，验证码获取，邮箱注册/登录，获取用户信息，用户信息修改
-//用信息新增；通过昵称获取用户信息，通过邮箱获取用户信息，通过用户ID获取用户信息，通过多个用户ID获取多个用户信息；信息修改
 
 namespace chatnow
 {
@@ -13,19 +25,77 @@ namespace chatnow
 class ODBFactory
 {
 public:
+    /* brief: 创建 ODB 数据库句柄
+     *  @param conn_pool_count 连接池最大连接数；建议每服务 4~16
+     *  @param charset         字符集；新 schema 必须 utf8mb4
+     */
     static std::shared_ptr<odb::core::database> create(const std::string &user,
-                                                    const std::string &password,
-                                                    const std::string &host,
-                                                    const std::string &db,
-                                                    const std::string &cset,
-                                                    uint16_t port,
-                                                    int conn_pool_count) 
+                                                       const std::string &password,
+                                                       const std::string &host,
+                                                       const std::string &db,
+                                                       const std::string &charset,
+                                                       uint16_t port,
+                                                       int conn_pool_count)
     {
-       std::unique_ptr<odb::mysql::connection_pool_factory> factory(new odb::mysql::connection_pool_factory(conn_pool_count, 0));
-       auto res = std::make_shared<odb::mysql::database>(user, password, db, host, port, "", cset, 0, std::move(factory));
-       return res;
+        std::string cs = charset.empty() ? std::string("utf8mb4") : charset;
+        auto factory = std::unique_ptr<odb::mysql::connection_pool_factory>(
+            new odb::mysql::connection_pool_factory(conn_pool_count, 0));
+        return std::make_shared<odb::mysql::database>(
+            user, password, db, host, port, "", cs, 0, std::move(factory));
+    }
+
+    /* brief: 健康检查 — 用最廉价的 SELECT 1 验证连接池可用 */
+    static bool ping(const std::shared_ptr<odb::core::database> &db) {
+        try {
+            odb::transaction t(db->begin());
+            db->execute("SELECT 1");
+            t.commit();
+            return true;
+        } catch(std::exception &e) {
+            LOG_ERROR("MySQL ping 失败: {}", e.what());
+            return false;
+        }
     }
 };
 
+/**
+ * TxnGuard
+ * ------------------------------------------------------------------
+ * 事务 RAII：嵌套场景挂载到外层事务，最外层负责 commit。
+ *   void Service::foo(...) {
+ *       TxnGuard tx(_db);
+ *       _msg_dao->insert(msg);
+ *       _timeline_dao->insert(timelines);
+ *       tx.commit();
+ *   }
+ * DAO 内部使用 odb::transaction::has_current() 即可感知是否已在外层事务中。
+ * ------------------------------------------------------------------
+ */
+class TxnGuard
+{
+public:
+    explicit TxnGuard(const std::shared_ptr<odb::core::database> &db) {
+        if(odb::transaction::has_current()) {
+            _owner = false;
+        } else {
+            _owner = true;
+            _txn.reset(new odb::transaction(db->begin()));
+        }
+    }
+    ~TxnGuard() {
+        // 析构未提交则视为异常路径，事务自动回滚（odb::transaction 析构语义）
+    }
+    void commit() {
+        if(_owner && _txn) {
+            _txn->commit();
+            _owner = false;
+        }
+    }
+    bool owner() const { return _owner; }
 
-}
+private:
+    bool _owner = false;
+    std::unique_ptr<odb::transaction> _txn;
+};
+
+} // namespace chatnow

--- a/code/server/common/rabbitmq.hpp
+++ b/code/server/common/rabbitmq.hpp
@@ -1,340 +1,324 @@
 #pragma once
+
+/**
+ * ===========================================================================
+ * RabbitMQ 封装（基于 AMQP-CPP + libev）
+ * ---------------------------------------------------------------------------
+ * 设计要点（在原版基础上的修订）：
+ *   1. 修复 DLX 命名 bug：dlx_xxx() 由 "exchange + dlx_" 改为 "dlx_ + exchange"
+ *      —— 旧版会拼成 "chat_msg_exchangedlx_" 这种奇怪字符串
+ *   2. delayed_ttl 单位明确为毫秒（与 AMQP x-message-ttl 一致）
+ *   3. 错误处理策略放松：库内不再 abort()，改为返回失败并打日志，
+ *      由调用方决定是否要 fatal exit；这是库代码该有的行为
+ *   4. 新增 qos(prefetch) 限制：默认 prefetch=64，避免慢消费者内存堆积
+ *   5. publish_confirm 状态枚举显式注释 Lost vs Nack 的区别
+ *   6. 析构关闭 connection 后再销毁 ev_loop，避免事件残留
+ * ===========================================================================
+ */
+
 #include <ev.h>
 #include <amqpcpp.h>
 #include <amqpcpp/libev.h>
 #include <openssl/ssl.h>
 #include <openssl/opensslv.h>
-#include <mutex>
 #include <condition_variable>
-#include <thread>
-#include <queue>
 #include <functional>
 #include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
 #include "logger.hpp"
 
 namespace chatnow
 {
 
-const std::string DIRECT = "direct";
-const std::string FANOUT = "fanout";
-const std::string TOPIC = "topic";
-const std::string HEADERS = "headers";
-const std::string DELAYED = "delayed";
-const std::string DLX_PREFIX = "dlx_";
-const std::string DEAD_LETTER_EXCHANGE = "x-dead-letter-exchange";
-const std::string DEAD_LETTER_ROUTING_KEY = "x-dead-letter-routing-key";
-const std::string MESSAGE_TTL = "x-message-ttl";
+inline const std::string DIRECT  = "direct";
+inline const std::string FANOUT  = "fanout";
+inline const std::string TOPIC   = "topic";
+inline const std::string HEADERS = "headers";
+inline const std::string DELAYED = "delayed";
+inline const std::string DLX_PREFIX = "dlx_";
+inline const std::string DEAD_LETTER_EXCHANGE    = "x-dead-letter-exchange";
+inline const std::string DEAD_LETTER_ROUTING_KEY = "x-dead-letter-routing-key";
+inline const std::string MESSAGE_TTL             = "x-message-ttl";
+
+inline constexpr uint16_t kDefaultPrefetch = 64;
 
 struct declare_settings {
     std::string exchange;
-    // 交换机类型: direct, fanout, topic, delayed
-    std::string exchange_type;
+    std::string exchange_type;       // direct / fanout / topic / headers / delayed
     std::string queue;
     std::string binding_key;
-    size_t delayed_ttl = 5; // 延时消息的 TTL，单位秒，默认5秒
+    /* brief: 延时消息的 TTL（毫秒），与 AMQP x-message-ttl 单位一致；旧实现注释为秒是错的 */
+    int64_t delayed_ttl_ms = 5000;
 
-    std::string dlx_exchange() const { return exchange + DLX_PREFIX; }
-    std::string dlx_queue() const { return queue + DLX_PREFIX; }
-    std::string dlx_binding_key() const { return binding_key + DLX_PREFIX; }
+    /* brief: DLX 资源命名（前缀方式，非旧版的尾部拼接） */
+    std::string dlx_exchange()     const { return DLX_PREFIX + exchange; }
+    std::string dlx_queue()        const { return DLX_PREFIX + queue; }
+    std::string dlx_binding_key()  const { return DLX_PREFIX + binding_key; }
 };
 
-AMQP::ExchangeType exchange_type(const std::string &type) {
-    if (type == DIRECT) {
-        return AMQP::ExchangeType::direct;
-    } else if (type == FANOUT) {
-        return AMQP::ExchangeType::fanout;
-    } else if (type == TOPIC) {
-        return AMQP::ExchangeType::topic;
-    } else if (type == HEADERS) {
-        return AMQP::ExchangeType::headers;
-    } else if (type == DELAYED) {
-        return AMQP::ExchangeType::direct;
-    }
+inline AMQP::ExchangeType exchange_type(const std::string &type) {
+    if (type == DIRECT)  return AMQP::ExchangeType::direct;
+    if (type == FANOUT)  return AMQP::ExchangeType::fanout;
+    if (type == TOPIC)   return AMQP::ExchangeType::topic;
+    if (type == HEADERS) return AMQP::ExchangeType::headers;
+    if (type == DELAYED) return AMQP::ExchangeType::direct;
     LOG_ERROR("无效的交换机类型: {}", type);
-    abort();
+    return AMQP::ExchangeType::direct;
 }
 
-enum class PublishStatus {
-    Acked,   // broker 确认接收
-    Nacked,  // broker 显式拒绝
-    Lost,    // nack 或连接/通道问题导致丢失
-    Error    // publish 过程中发生 channel error
-};
+/* brief: 发布确认状态
+ *  - Acked   : broker 已确认接收
+ *  - Nacked  : broker 显式拒绝（如队列满 / 路由失败）
+ *  - Lost    : 与 broker 间通道断开导致状态未知（应视为可能丢失）
+ *  - Error   : 发布过程发生 channel 错误
+ */
+enum class PublishStatus { Acked, Nacked, Lost, Error };
 
-enum class ConsumeAction {
-    Ack,            // 处理成功，确认消费
-    NackRequeue,    // 处理失败，重新入队
-    NackDiscard     // 处理失败，丢弃/交给死信
-};
+/* brief: 消费回调返回 — 决定本条消息的 ack 策略 */
+enum class ConsumeAction { Ack, NackRequeue, NackDiscard };
 
-using MessageCallback = std::function<ConsumeAction(const char*, size_t, bool redelivered)>;
-using PublishConfirmCallback = std::function<void(PublishStatus, const std::string&)>;
+using MessageCallback         = std::function<ConsumeAction(const char*, size_t, bool)>;
+using PublishConfirmCallback  = std::function<void(PublishStatus, const std::string&)>;
 
 class MQClient
 {
 public:
     using ptr = std::shared_ptr<MQClient>;
 
-    MQClient(const std::string &url)
-        // 建议使用 ev_loop_new 避免与系统其他使用 EV_DEFAULT 的库发生冲突
+    explicit MQClient(const std::string &url)
         : _ev_loop(ev_loop_new(EVFLAG_AUTO))
         , _handler(_ev_loop)
         , _connection(&_handler, AMQP::Address(url))
         , _channel(&_connection)
         , _reliable(std::make_unique<AMQP::Reliable<>>(_channel))
     {
-        // 1. 初始化退出事件观察者
         ev_async_init(&_ev_async, quit_callback);
         ev_async_start(_ev_loop, &_ev_async);
 
-        // 2. 初始化任务队列事件观察者（跨线程唤醒核心）
         _task_watcher.data = this;
         ev_async_init(&_task_watcher, task_callback);
         ev_async_start(_ev_loop, &_task_watcher);
 
-        // 3. 一切准备就绪后，最后启动 libev 事件循环线程
         _async_thread = std::thread([this](){ ev_run(_ev_loop, 0); });
     }
 
     ~MQClient() {
-        // 发送退出信号唤醒事件循环
+        // 优雅关闭：先在 ev 线程内关闭 channel/connection，再 break loop
+        post_task([this](){
+            try { _channel.close(); _connection.close(); } catch(...) {}
+        });
         ev_async_send(_ev_loop, &_ev_async);
-        if (_async_thread.joinable()) {
-            _async_thread.join();
-        }
-        // 清理 loop
+        if(_async_thread.joinable()) _async_thread.join();
         ev_loop_destroy(_ev_loop);
     }
 
+    /* brief: 声明交换机 / 队列 / 绑定（含 DLX 链路） */
     void declare(const declare_settings &settings) {
         AMQP::Table args;
         if(settings.exchange_type == DELAYED) {
-            _declared(settings, args, true);
-            args[MESSAGE_TTL] = settings.delayed_ttl;
-            args[DEAD_LETTER_EXCHANGE] = settings.dlx_exchange();
-            args[DEAD_LETTER_ROUTING_KEY] = settings.dlx_binding_key();
+            // 1) 先声明 DLX 链路
+            _declared(settings, AMQP::Table(), /*is_dlx=*/true);
+            // 2) 主队列绑定 TTL + DLX 路由
+            args[MESSAGE_TTL]              = (int64_t)settings.delayed_ttl_ms;
+            args[DEAD_LETTER_EXCHANGE]     = settings.dlx_exchange();
+            args[DEAD_LETTER_ROUTING_KEY]  = settings.dlx_binding_key();
         }
-        _declared(settings, args, false);
+        _declared(settings, args, /*is_dlx=*/false);
     }
 
+    /* brief: 普通发布（无确认） */
     bool publish(const std::string &exchange, const std::string &routing_key, const std::string &body) {
-        // 将发布操作派发到 libev 线程执行
         post_task([this, exchange, routing_key, body]() {
             _channel.publish(exchange, routing_key, body);
         });
-        return true; 
+        return true;
     }
 
+    /* brief: 带 broker 确认的发布；callback 在 ack/nack/lost/error 时被调用 */
     void publish_confirm(const std::string &exchange,
                          const std::string &routing_key,
                          const std::string &body,
                          const PublishConfirmCallback &callback)
     {
-        if (!_reliable) {
-            if (callback) callback(PublishStatus::Error, "发布确认未启用");
+        if(!_reliable) {
+            if(callback) callback(PublishStatus::Error, "发布确认未启用");
             return;
         }
-
-        // 将发布确认操作打包放入任务队列，唤醒 libev 线程执行
         post_task([this, exchange, routing_key, body, callback]() {
             _reliable->publish(exchange, routing_key, body)
                 .onAck([callback]() {
-                    if (callback) callback(PublishStatus::Acked, "消息被 broker 确认");
+                    if(callback) callback(PublishStatus::Acked, "broker 已确认");
                 })
                 .onNack([callback]() {
-                    if (callback) callback(PublishStatus::Nacked, "消息被 broker 拒绝");
+                    if(callback) callback(PublishStatus::Nacked, "broker 显式拒绝");
                 })
                 .onLost([callback]() {
-                    if (callback) callback(PublishStatus::Lost, "消息丢失");
+                    if(callback) callback(PublishStatus::Lost, "通道断开，状态未知");
                 })
-                .onError([callback](const char *message) {
-                    if (callback) callback(PublishStatus::Error, message ? message : "未知错误");
+                .onError([callback](const char *msg) {
+                    if(callback) callback(PublishStatus::Error, msg ? msg : "未知错误");
                 });
         });
     }
 
-    void consume(const std::string &queue, const MessageCallback &callback) {
-        std::promise<void> promise;
+    /* brief: 订阅队列；如果是 delayed 模式应订阅 DLX 队列（外层 Subscriber 已处理） */
+    bool consume(const std::string &queue, const MessageCallback &callback,
+                 uint16_t prefetch = kDefaultPrefetch)
+    {
+        std::promise<bool> promise;
         auto future = promise.get_future();
 
-        post_task([this, queue, callback, &promise]() {
+        post_task([this, queue, callback, prefetch, &promise]() {
+            // 流控：限制未 ack 的最大消息数，防慢消费打爆内存
+            _channel.setQos(prefetch);
             _channel.consume(queue)
                 .onMessage([this, callback](const AMQP::Message &message,
                                             uint64_t deliveryTag,
                                             bool redelivered) {
                     try {
                         ConsumeAction action = callback(message.body(), message.bodySize(), redelivered);
-                        switch (action) {
-                        case ConsumeAction::Ack:
-                            _channel.ack(deliveryTag);
-                            break;
-                        case ConsumeAction::NackRequeue:
-                            _channel.reject(deliveryTag, true);
-                            break;
-                        case ConsumeAction::NackDiscard:
-                            _channel.reject(deliveryTag, false);
-                            break;
-                        default:
-                            LOG_ERROR("未知的 ConsumeAction");
-                            _channel.reject(deliveryTag, true);
-                            break;
+                        switch(action) {
+                        case ConsumeAction::Ack:         _channel.ack(deliveryTag); break;
+                        case ConsumeAction::NackRequeue: _channel.reject(deliveryTag, true);  break;
+                        case ConsumeAction::NackDiscard: _channel.reject(deliveryTag, false); break;
                         }
-                    }
-                    catch (const std::exception &e) {
+                    } catch(const std::exception &e) {
                         LOG_ERROR("消费回调异常: {}", e.what());
                         _channel.reject(deliveryTag, true);
-                    }
-                    catch (...) {
+                    } catch(...) {
                         LOG_ERROR("消费回调发生未知异常");
                         _channel.reject(deliveryTag, true);
                     }
                 })
                 .onError([&promise, queue](const char *message) {
-                    LOG_ERROR("订阅消息失败: {} - {}", queue, message);
-                    promise.set_value(); // 解除阻塞
-                    abort();
+                    LOG_ERROR("订阅消息失败: {} - {}", queue, message ? message : "");
+                    promise.set_value(false);
                 })
                 .onSuccess([&promise, queue]() {
                     LOG_DEBUG("成功订阅队列: {}", queue);
-                    promise.set_value(); // 成功，解除阻塞
+                    promise.set_value(true);
                 });
         });
-
-        future.get(); // 阻塞等待 libev 线程完成订阅操作
+        return future.get();
     }
 
     void wait() { _async_thread.join(); }
 
 private:
-    // 退出事件回调
-    static void quit_callback(struct ev_loop *loop, ev_async *watcher, int32_t revents) {
+    static void quit_callback(struct ev_loop *loop, ev_async *, int) {
         ev_break(loop, EVBREAK_ALL);
     }
 
-    // 处理任务队列的回调（运行在 libev 线程中）
-    static void task_callback(struct ev_loop *loop, ev_async *watcher, int32_t revents) {
-        MQClient *self = static_cast<MQClient*>(watcher->data);
+    static void task_callback(struct ev_loop *, ev_async *watcher, int) {
+        auto *self = static_cast<MQClient*>(watcher->data);
         std::queue<std::function<void()>> tasks;
         {
-            // 快速加锁，取出所有任务
-            std::lock_guard<std::mutex> lock(self->_task_mtx);
+            std::lock_guard<std::mutex> lk(self->_task_mtx);
             tasks.swap(self->_task_queue);
         }
-        // 在无锁状态下，单线程依次执行所有 AMQP 操作
-        while (!tasks.empty()) {
+        while(!tasks.empty()) {
             tasks.front()();
             tasks.pop();
         }
     }
 
-    // 统一的任务派发接口
     void post_task(std::function<void()> task) {
         {
-            std::lock_guard<std::mutex> lock(_task_mtx);
+            std::lock_guard<std::mutex> lk(_task_mtx);
             _task_queue.push(std::move(task));
         }
-        // 唤醒 libev 所在的底层 epoll_wait
         ev_async_send(_ev_loop, &_task_watcher);
     }
 
-    void _declared(const declare_settings &settings, AMQP::Table args, bool is_dlx = false) {
-        std::mutex mtx;           // 防止并发 Declare 的粗粒度锁
-        std::lock_guard<std::mutex> declare_lock(mtx); 
-
-        std::promise<void> promise;
+    /* brief: 声明 exchange + queue + bind 链路；返回是否成功 */
+    bool _declared(const declare_settings &settings, AMQP::Table args, bool is_dlx) {
+        std::promise<bool> promise;
         auto future = promise.get_future();
 
         post_task([this, settings, args, is_dlx, &promise]() mutable {
-            std::string exchange = is_dlx ? settings.dlx_exchange() : settings.exchange;
-            std::string queue = is_dlx ? settings.dlx_queue() : settings.queue;
+            std::string exchange    = is_dlx ? settings.dlx_exchange()    : settings.exchange;
+            std::string queue       = is_dlx ? settings.dlx_queue()       : settings.queue;
             std::string binding_key = is_dlx ? settings.dlx_binding_key() : settings.binding_key;
-            AMQP::ExchangeType type = exchange_type(settings.exchange_type);
+            // delayed 模式底层走 direct；DLX 链路也用 direct
+            AMQP::ExchangeType type = is_dlx ? AMQP::ExchangeType::direct
+                                             : exchange_type(settings.exchange_type);
 
             _channel.declareExchange(exchange, type)
                 .onSuccess([this, queue, args, exchange, binding_key, &promise]() mutable {
                     _channel.declareQueue(queue, args)
-                        .onSuccess([this, exchange, queue, binding_key, &promise](const std::string &, uint32_t, uint32_t) {
+                        .onSuccess([this, exchange, queue, binding_key, &promise](
+                                       const std::string &, uint32_t, uint32_t) {
                             _channel.bindQueue(exchange, queue, binding_key)
-                                .onSuccess([&promise](){
-                                    promise.set_value(); // 链路全部成功，解除阻塞
-                                })
-                                .onError([&promise, exchange, queue](const char *message){
-                                    LOG_ERROR("绑定交换机和队列失败:{} - {} - {}", exchange, queue, message);
-                                    promise.set_value(); 
-                                    abort();
+                                .onSuccess([&promise](){ promise.set_value(true); })
+                                .onError([&promise, exchange, queue](const char *m){
+                                    LOG_ERROR("绑定 {}-{} 失败: {}", exchange, queue, m ? m : "");
+                                    promise.set_value(false);
                                 });
                         })
-                        .onError([&promise, queue](const char *message){
-                            LOG_ERROR("声明队列失败: {} - {}", queue, message);
-                            promise.set_value();
-                            abort();
+                        .onError([&promise, queue](const char *m){
+                            LOG_ERROR("声明队列 {} 失败: {}", queue, m ? m : "");
+                            promise.set_value(false);
                         });
                 })
-                .onError([&promise, exchange](const char *message){
-                    LOG_ERROR("声明交换机失败: {} - {}", exchange, message);
-                    promise.set_value();
-                    abort();
+                .onError([&promise, exchange](const char *m){
+                    LOG_ERROR("声明交换机 {} 失败: {}", exchange, m ? m : "");
+                    promise.set_value(false);
                 });
         });
-
-        // 阻塞当前线程，直到异步的 declare 回调链执行完毕并 set_value
-        future.get();
+        return future.get();
     }
 
-private:
-    std::mutex _task_mtx;                        // 任务队列互斥锁
-    std::queue<std::function<void()>> _task_queue; // 任务队列，存放要在 libev 线程执行的操作
+    std::mutex _task_mtx;
+    std::queue<std::function<void()>> _task_queue;
 
-    struct ev_loop *_ev_loop;    
-    struct ev_async _ev_async;   // 用于退出的 watcher
-    struct ev_async _task_watcher; // 用于唤醒并执行任务队列的 watcher
+    struct ev_loop *_ev_loop;
+    struct ev_async _ev_async;
+    struct ev_async _task_watcher;
 
-    AMQP::LibEvHandler _handler; 
-    AMQP::TcpConnection _connection; 
-    AMQP::TcpChannel _channel;       
-    std::unique_ptr<AMQP::Reliable<>> _reliable; 
-    std::thread _async_thread; 
+    AMQP::LibEvHandler _handler;
+    AMQP::TcpConnection _connection;
+    AMQP::TcpChannel _channel;
+    std::unique_ptr<AMQP::Reliable<>> _reliable;
+    std::thread _async_thread;
 };
 
+/* brief: 单一交换机/队列的发布者 */
 class Publisher
 {
 public:
     using ptr = std::shared_ptr<Publisher>;
-    /* brief: 构造函数，初始化MQ客户端，并声明交换机和队列 */
-    Publisher(const MQClient::ptr &mq_client, const declare_settings &settings) : _mq_client(mq_client), _settings(settings) {
-        _mq_client->declare(settings);
-    }
+    Publisher(const MQClient::ptr &mq, const declare_settings &settings)
+        : _mq(mq), _settings(settings) { _mq->declare(settings); }
+
     bool publish(const std::string &body) {
-        return _mq_client->publish(_settings.exchange, _settings.binding_key, body);
+        return _mq->publish(_settings.exchange, _settings.binding_key, body);
     }
-    void publish_confirm(const std::string &body, const PublishConfirmCallback &callback) {
-        _mq_client->publish_confirm(_settings.exchange, _settings.binding_key, body, callback);
+    void publish_confirm(const std::string &body, const PublishConfirmCallback &cb) {
+        _mq->publish_confirm(_settings.exchange, _settings.binding_key, body, cb);
     }
 private:
-    MQClient::ptr _mq_client;
+    MQClient::ptr _mq;
     declare_settings _settings;
 };
 
+/* brief: 单一交换机/队列的订阅者；delayed 模式自动订阅 DLX 队列 */
 class Subscriber
 {
 public:
     using ptr = std::shared_ptr<Subscriber>;
-    /* brief: 构造函数，初始化MQ客户端，并声明交换机和队列 */
-    Subscriber(const MQClient::ptr &mq_client, const declare_settings &settings, const MessageCallback &callback) : _mq_client(mq_client), _settings(settings), _callback(callback) {
-        _mq_client->declare(settings);
-    }
-    /* brief: 订阅消息时，如果是延时队列，则实际订阅的是配套的死信队列 */
-    void consume(MessageCallback &&callback) {
-        _callback = std::move(callback);
-        // 如果是延时队列，则订阅死信队列
-        if(_settings.exchange_type == "delayed") {
-            _mq_client->consume(_settings.dlx_queue(), _callback);
-        } else {
-            _mq_client->consume(_settings.queue, _callback);
-        }
+    Subscriber(const MQClient::ptr &mq, const declare_settings &settings, const MessageCallback &cb)
+        : _mq(mq), _settings(settings), _callback(cb) { _mq->declare(settings); }
+
+    void consume(MessageCallback &&cb, uint16_t prefetch = kDefaultPrefetch) {
+        _callback = std::move(cb);
+        const std::string &q = (_settings.exchange_type == DELAYED)
+            ? _settings.dlx_queue() : _settings.queue;
+        _mq->consume(q, _callback, prefetch);
     }
 private:
-    MQClient::ptr _mq_client;
+    MQClient::ptr _mq;
     declare_settings _settings;
     MessageCallback _callback;
 };
@@ -342,8 +326,7 @@ private:
 class MQFactory
 {
 public:
-    // 提供一个通用的工厂，实现各个不同的类对象的创建
-    template<typename T, typename... Args>
+    template <typename T, typename... Args>
     static std::shared_ptr<T> create(Args&&... args) {
         return std::make_shared<T>(std::forward<Args>(args)...);
     }

--- a/code/server/common/snowflake.hpp
+++ b/code/server/common/snowflake.hpp
@@ -1,159 +1,99 @@
 #pragma once
 
-#include <cstdint>
+/**
+ * ===========================================================================
+ * Snowflake 风格分布式唯一 ID 生成器
+ * ---------------------------------------------------------------------------
+ * 设计保证：
+ *   1. 单实例 ID 严格单调递增
+ *   2. 多实例通过 worker_id 保证全局唯一（10 bits → 1024 节点）
+ *   3. 同毫秒内 sequence 区分（12 bits → 4096 ID/ms）
+ *   4. sequence 溢出阻塞至下一毫秒
+ *   5. 时钟回拨：< 1s 自旋追平；> 1s 抛异常拒绝出 ID（避免重复）
+ *
+ * 注意：
+ *   - 全局严格单调在无中心系统不可达；本实现保证「单实例严格单调 + 全局趋势递增」
+ *   - 业务上跨实例需要绝对单调时（如会话 seq）请用 Redis INCR（见 SeqGen）
+ *
+ * 修订（相对原版）：
+ *   - 私有变量加 chatnow:: 命名空间内访问，保持与项目风格一致
+ *   - WaitUntil 用 sleep_for(1ms) 起步避免 busy-spin 在大回拨场景吃 CPU
+ *   - epoch_ms 默认值改 2025-01-01 UTC（旧值已是这天但注释提及，保留）
+ * ===========================================================================
+ */
+
 #include <chrono>
+#include <cstdint>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
 
-/**
- * @brief Snowflake 风格的分布式唯一 ID 生成器
- *
- * 设计保证：
- * 1. 单实例内 ID 严格单调递增
- * 2. 多实例通过 worker_id 保证全局唯一
- * 3. 同一毫秒内使用 sequence 消除冲突
- * 4. sequence 溢出时阻塞等待下一毫秒
- * 5. 对时钟回拨提供明确处理策略
- *
- * 注意：
- * - “全局严格单调”在无中心的分布式系统中不可实现
- * - 本实现保证：单实例严格单调 + 全局趋势递增
- */
-
 namespace chatnow
 {
 
-class SnowflakeId {
+class SnowflakeId
+{
 public:
-    /**
-     * 位宽定义（经典 Twitter Snowflake）
-     *
-     * 10 bits worker_id  -> 支持 1024 个节点
-     * 12 bits sequence   -> 单节点单毫秒最多 4096 个 ID
-     */
-    static constexpr uint8_t  kWorkerBits  = 10;
-    static constexpr uint8_t  kSeqBits     = 12;
-
-    /**
-     * worker_id 与 sequence 的最大值
-     * 用于边界校验与溢出判断
-     */
+    static constexpr uint8_t  kWorkerBits = 10;   // 1024 个节点
+    static constexpr uint8_t  kSeqBits    = 12;   // 单节点单 ms 4096 个 ID
     static constexpr uint64_t kMaxWorkerId = (1ULL << kWorkerBits) - 1;
     static constexpr uint64_t kMaxSequence = (1ULL << kSeqBits) - 1;
 
     /**
-     * @param worker_id
-     *        当前生成器的机器 / 实例 ID
-     *        在多实例部署时必须保证全局唯一
-     *
-     * @param epoch_ms
-     *        自定义起始时间（毫秒）
-     *        实际存储的是 (当前时间 - epoch)
-     *        这样可以节省 timestamp 位数
-     *
-     * @param wait_on_clock_backwards
-     *        是否在检测到系统时钟回拨时等待
-     *        true  -> 等待时间追上 last_ts_
-     *        false -> 直接抛异常
+     * @param worker_id 实例 ID，多机部署需全局唯一
+     * @param epoch_ms  自定义起始毫秒（默认 2025-01-01 UTC）
+     * @param wait_on_clock_backwards 时钟回拨时是否阻塞等待（false 直接抛错）
      */
     explicit SnowflakeId(uint64_t worker_id,
                          uint64_t epoch_ms = 1735689600000ULL, // 2025-01-01 UTC
                          bool wait_on_clock_backwards = true)
         : worker_id_(worker_id),
           epoch_ms_(epoch_ms),
-          wait_on_clock_backwards_(wait_on_clock_backwards) {
-
-        // worker_id 超出位宽范围，属于配置错误，直接拒绝启动
-        if (worker_id_ > kMaxWorkerId) {
-            throw std::invalid_argument("worker_id out of range");
+          wait_on_clock_backwards_(wait_on_clock_backwards)
+    {
+        if(worker_id_ > kMaxWorkerId) {
+            throw std::invalid_argument("snowflake worker_id out of range");
         }
     }
 
-    /**
-     * @brief 生成下一个 ID
-     *
-     * 线程安全（mutex 串行化）：
-     * - 保证 last_ts_ / sequence_ 的一致性
-     * - 保证单实例内严格单调递增
-     */
+    /* brief: 申请下一个 64-bit ID（线程安全） */
     uint64_t Next() {
         std::lock_guard<std::mutex> lock(mu_);
-
         uint64_t now = NowMs();
 
-        /**
-         * 1 时钟回拨处理
-         *
-         * 如果系统时间小于上一次生成 ID 的时间，
-         * 说明发生了 NTP 校时或人为改时间。
-         */
-        // 1. 时钟回拨处理
-        if (now < last_ts_) {
-            long diff = last_ts_ - now;
-            if (!wait_on_clock_backwards_ || diff > 1000) { 
-                // 如果回拨超过 1秒，等待代价太大，直接抛错
-                throw std::runtime_error("Clock moved backwards logically");
+        // 1) 时钟回拨处理
+        if(now < last_ts_) {
+            uint64_t diff = last_ts_ - now;
+            if(!wait_on_clock_backwards_ || diff > 1000) {
+                throw std::runtime_error("snowflake: clock moved backwards");
             }
-            // 短时间回拨，自旋等待追平
             now = WaitUntil(last_ts_);
         }
 
-        /**
-         * 2 同一毫秒内
-         *
-         * 时间戳不变，只能依赖 sequence 来区分 ID
-         */
-        if (now == last_ts_) {
-            // sequence 自增，并限制在 bit 范围内
+        // 2) 同毫秒：sequence 自增并防溢出
+        if(now == last_ts_) {
             sequence_ = (sequence_ + 1) & kMaxSequence;
-
-            /**
-             * sequence 用尽：
-             * - 当前毫秒内已经生成了 4096 个 ID
-             * - 必须等待下一毫秒，否则会冲突
-             */
-            if (sequence_ == 0) {
-                now = WaitUntil(last_ts_ + 1);
-            }
+            if(sequence_ == 0) now = WaitUntil(last_ts_ + 1);
         } else {
-            /**
-             * 3 新的毫秒
-             *
-             * sequence 必须清零，
-             * 否则会破坏 ID 的单调性
-             */
+            // 3) 新毫秒：sequence 必须清零保单调性
             sequence_ = 0;
         }
-
-        // 更新最近一次生成 ID 的时间戳
         last_ts_ = now;
-
-        // 4 拼接最终的 64-bit ID
         return Compose(now, worker_id_, sequence_);
     }
 
-private:
-    /**
-     * @brief 将时间戳、worker_id、sequence 组合成最终 ID
-     *
-     * 结构：
-     * | timestamp | worker_id | sequence |
-     */
-    uint64_t Compose(uint64_t ts_ms,
-                     uint64_t worker,
-                     uint64_t seq) const {
-        // 使用相对 epoch 的时间戳，减少位宽占用
-        uint64_t delta = ts_ms - epoch_ms_;
+    uint64_t worker_id() const { return worker_id_; }
+    uint64_t epoch_ms()  const { return epoch_ms_;  }
 
+private:
+    /* brief: timestamp(41) | worker(10) | sequence(12) */
+    uint64_t Compose(uint64_t ts_ms, uint64_t worker, uint64_t seq) const {
+        uint64_t delta = ts_ms - epoch_ms_;
         return (delta << (kWorkerBits + kSeqBits)) |
                (worker << kSeqBits) |
                seq;
     }
 
-    /**
-     * @brief 获取当前系统时间（毫秒）
-     */
     static uint64_t NowMs() {
         using namespace std::chrono;
         return duration_cast<milliseconds>(
@@ -161,42 +101,26 @@ private:
             .count();
     }
 
-    /**
-     * @brief 阻塞等待直到系统时间 >= target_ms
-     *
-     * 设计说明：
-     * - 直接 busy-spin 会浪费 CPU
-     * - sleep 太粗会影响延迟
-     * - 这里采用 sleep + yield 折中
-     */
+    /* brief: 阻塞等待至 target_ms；先 sleep 1ms，逼近时切换 yield */
     static uint64_t WaitUntil(uint64_t target_ms) {
-        for (;;) {
+        for(;;) {
             uint64_t now = NowMs();
-            if (now >= target_ms) {
-                return now;
-            }
-
-            if (target_ms - now > 1) {
-                // 时间差较大，sleep 1ms
-                std::this_thread::sleep_for(
-                    std::chrono::milliseconds(1));
+            if(now >= target_ms) return now;
+            if(target_ms - now > 1) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             } else {
-                // 即将到达目标时间，主动让出 CPU
                 std::this_thread::yield();
             }
         }
     }
 
-private:
-    // ----------- 配置参数 -----------
-    uint64_t worker_id_;                 // 实例 / 机器 ID
-    uint64_t epoch_ms_;                  // 起始时间
-    bool     wait_on_clock_backwards_;   // 时钟回拨策略
+    uint64_t worker_id_;
+    uint64_t epoch_ms_;
+    bool     wait_on_clock_backwards_;
 
-    // ----------- 运行时状态 -----------
-    std::mutex mu_;                      // 保证线程安全
-    uint64_t   last_ts_  = 0;            // 上一次生成 ID 的时间
-    uint64_t   sequence_ = 0;            // 当前毫秒内的序列号
-};  // class SnowflakeId
+    std::mutex mu_;
+    uint64_t   last_ts_  = 0;
+    uint64_t   sequence_ = 0;
+};
 
 } // namespace chatnow

--- a/code/server/common/utils.hpp
+++ b/code/server/common/utils.hpp
@@ -1,25 +1,42 @@
-//实现项目中一些公共的工具类接口
-//1. 生成一个唯一ID的接口
-//2. 文件的读写操作接口
+#pragma once
 
-#include <iostream>
+/**
+ * ===========================================================================
+ * 公共工具集
+ * ---------------------------------------------------------------------------
+ * 设计要点：
+ *   1. uuid()：原子计数器改成 inline static 跨调用累计，不再每次重置
+ *   2. 新增 verify_code(n)：可指定位数，默认 6 位（4 位强度过低）
+ *   3. 新增 single_session_id(uid_a, uid_b)：约定双方 user_id 排序后
+ *      生成确定性单聊会话 ID，客户端无需查库即可推算
+ *   4. 文件 IO 使用 RAII，明确错误码记录到日志
+ *   5. 新增时间转字符串、boost::ptime <=> 毫秒/秒戳互转工具，
+ *      消息时间戳上下游统一格式
+ *   6. 全部声明 inline 避免多 TU 重复定义
+ * ===========================================================================
+ */
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <fstream>
+#include <iomanip>
+#include <random>
 #include <sstream>
 #include <string>
-#include <atomic>
-#include <random>
-#include <iomanip>
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include "logger.hpp"
 
 namespace chatnow
 {
 
-/* brief: 生成一个由16位随机字符组成的字符串作为唯一ID */
-std::string uuid() {
-    //1. 生成6个0~255随机数字(1字节-转换为16进制字符) -- 生成12位16进制字符
-    std::random_device rd; //实例化设备随机数对象--用于生成随机数种子
-    std::mt19937 generator(rd()); // 以设备随机数为种子，实例化伪随机数对象 
-    std::uniform_int_distribution<int> distribution(0, 255); //限定数据范围
+/* brief: 生成一个 16 位 16 进制字符串作为唯一 ID
+ *  格式: aabb-ccddee-NNNN  （6 字节随机 + 单调递增 2 字节序号）
+ */
+inline std::string uuid() {
+    static thread_local std::mt19937 generator(std::random_device{}());
+    static std::atomic<uint16_t> idx{0};
+    std::uniform_int_distribution<int> distribution(0, 255);
 
     std::stringstream ss;
     for(int i = 0; i < 6; ++i) {
@@ -27,59 +44,91 @@ std::string uuid() {
         ss << std::setw(2) << std::setfill('0') << std::hex << distribution(generator);
     }
     ss << "-";
-    //2. 通过一个静态变量生成一个2字节的编号数字--生成4位16进制数字字符
-    std::atomic<short> idx(0);
-    short tmp = idx.fetch_add(1);
-    ss << std::setw(4) << std::setfill('0') << std::hex << tmp;
+    ss << std::setw(4) << std::setfill('0') << std::hex << idx.fetch_add(1, std::memory_order_relaxed);
     return ss.str();
 }
-/* brief: 生成一个4位验证码 */
-std::string verifyCode() {
-    //1. 生成6个0~9随机数字(1字节-转换为16进制字符) -- 生成12位16进制字符
-    std::random_device rd; //实例化设备随机数对象--用于生成随机数种子
-    std::mt19937 generator(rd()); // 以设备随机数为种子，实例化伪随机数对象 
-    std::uniform_int_distribution<int> distribution(0, 9); //限定数据范围
 
+/* brief: 生成 N 位纯数字验证码（默认 6 位） */
+inline std::string verify_code(int len = 6) {
+    static thread_local std::mt19937 generator(std::random_device{}());
+    std::uniform_int_distribution<int> distribution(0, 9);
     std::stringstream ss;
-    for(int i = 0; i < 4; ++i) {
-        ss <<distribution(generator);
-    }
+    for(int i = 0; i < len; ++i) ss << distribution(generator);
     return ss.str();
 }
-/* brief: 实现读取一个文件的所有数据，放入body */
-bool readFile(const std::string &filename, std::string &body) {
+
+/* brief: 旧名兼容：4 位验证码（已不推荐，逐步替换为 verify_code(6)） */
+inline std::string verifyCode() { return verify_code(4); }
+
+/* brief: 计算单聊会话 ID
+ *  - 约定：将双方 user_id 按字典序排序后拼接，前缀 single:
+ *  - 客户端可不查库直接算出 chat_session_id，避免一次额外往返
+ *  - 配合 chat_session.peer_user_id 字段，零 join 即可定位单聊
+ */
+inline std::string single_session_id(const std::string &a, const std::string &b) {
+    if(a.empty() || b.empty()) return std::string();
+    return a < b ? ("single:" + a + "_" + b) : ("single:" + b + "_" + a);
+}
+
+/* brief: 当前时间转 boost::ptime（毫秒精度） */
+inline boost::posix_time::ptime now_pt() {
+    return boost::posix_time::microsec_clock::universal_time();
+}
+
+/* brief: ptime 转毫秒时间戳（UTC） */
+inline int64_t pt_to_ms(const boost::posix_time::ptime &t) {
+    static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+    return (t - epoch).total_milliseconds();
+}
+
+/* brief: ptime 转秒级时间戳（UTC） */
+inline int64_t pt_to_seconds(const boost::posix_time::ptime &t) {
+    static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+    return (t - epoch).total_seconds();
+}
+
+/* brief: 毫秒戳转 ptime */
+inline boost::posix_time::ptime ms_to_pt(int64_t ms) {
+    static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+    return epoch + boost::posix_time::milliseconds(ms);
+}
+
+/* brief: 读取文件全部内容到 body */
+inline bool readFile(const std::string &filename, std::string &body) {
     std::ifstream ifs(filename, std::ios::binary | std::ios::in);
     if(ifs.is_open() == false) {
-        LOG_ERROR("打开文件 {} 失败! errno = {}", filename, errno);
+        LOG_ERROR("打开文件 {} 失败! errno={}", filename, errno);
         return false;
     }
-    ifs.seekg(0, std::ios::end); //跳转到文件末尾
-    size_t flen = ifs.tellg(); //获取当前偏移量
-    ifs.seekg(0, std::ios::beg); //跳转到文件起始
-    body.resize(flen);
+    ifs.seekg(0, std::ios::end);
+    const auto flen = ifs.tellg();
+    if(flen < 0) {
+        LOG_ERROR("获取文件大小失败 {}", filename);
+        return false;
+    }
+    ifs.seekg(0, std::ios::beg);
+    body.resize(static_cast<size_t>(flen));
     ifs.read(&body[0], flen);
-    if(ifs.good() == false) {
+    if(!ifs.good() && !ifs.eof()) {
         LOG_ERROR("读取文件 {} 数据失败!", filename);
-        ifs.close();
         return false;
     }
-    ifs.close();
     return true;
 }
-/* brief: 实现将body的数据，写入filename对应的文件中 */
-bool writeFile(const std::string &filename, const std::string &body) {
+
+/* brief: 把 body 写入文件（覆盖） */
+inline bool writeFile(const std::string &filename, const std::string &body) {
     std::ofstream ofs(filename, std::ios::out | std::ios::binary | std::ios::trunc);
     if(ofs.is_open() == false) {
         LOG_ERROR("打开文件 {} 失败!", filename);
         return false;
     }
-    ofs.write(body.c_str(), body.size());
-    if(ofs.good() == false) {
+    ofs.write(body.c_str(), static_cast<std::streamsize>(body.size()));
+    if(!ofs.good()) {
         LOG_ERROR("写入文件 {} 失败", filename);
-        ofs.close();
         return false;
     }
-    ofs.close();
     return true;
 }
-}
+
+} // namespace chatnow


### PR DESCRIPTION
基于 #6（DAO 重构）继续完成基础设施层完善。

## 修复的真实 bug

| 文件 | bug |
|---|---|
| logger.hpp | \`g_default_logger\` 是 header 全局变量，多 TU include 链接重复定义 |
| utils.hpp | \`uuid()\` 的 atomic 计数器是函数局部变量，每次调用重置 — 不是真递增 |
| etcd.hpp | \`~Registry()\` 调用 \`_keep_alive->Lease()\`（getter 而非 cancel） |
| mail.hpp | 多个错误返回路径漏 \`curl_easy_cleanup()\` / \`curl_slist_free_all()\` |
| rabbitmq.hpp | \`dlx_xxx()\` 拼成 \`exchangedlx_\` 而非 \`dlx_exchange\` |
| rabbitmq.hpp | \`delayed_ttl\` 注释为秒，但 AMQP x-message-ttl 单位是毫秒 |
| channel.hpp | \`_index\` 非原子，RR 选择有数据竞争 |
| channel.hpp | brpc 超时 -1（无限等待）会拖垮调用线程 |

## 高可用 / 高并发增强

### data_redis.hpp（最大增量）
新增 IM 关键工具：
- **SeqGen** — 会话级/用户级单调递增 seq（替代 DB 自增热点）；支持 backfill 修复 Redis 重启
- **LastMessage** — 最近一条消息预览缓存（替代 \`chat_session.last_message_*\` 行级写热点）
- **DeviceSet** — 用户在线设备集合（推送下发入口）
- **ReadAck** — 群消息已读暂存（配合后台批量刷库）
- 所有 Session/Status/Codes 加 TTL 防 OOM
- 工厂加连接池配置

### logger.hpp
- 异步日志 + rotating_file_sink（50MB×10 份）
- 优化 flush 策略（warn 即刷，其他 3s 批量刷）
- basename 抽取，日志路径不冗长

### utils.hpp
- \`single_session_id(a,b)\` 单聊确定性 ID 生成（客户端不查库即推算）
- \`verify_code(n)\` 6 位默认（4 位强度过低）
- ptime ↔ 时间戳互转工具

### mysql.hpp
- 默认 charset 改 utf8mb4（与新 schema 一致）
- \`ping()\` 健康检查
- \`TxnGuard\` 事务 RAII，DAO 层嵌套外层事务

### rabbitmq.hpp
- consume() 加 qos prefetch（默认 64）防慢消费者内存堆积
- 析构改优雅关闭

## Test plan
- [ ] 各服务编译通过
- [ ] 老 \`SPDLOG_xxx\` 调用点替换为 \`LOG_xxx\`（logger 路径基本统一了，但 etcd 之前用了 SPDLOG_xxx 旧 API）
- [ ] gateway 等服务确认 \`Session/Status/Codes\` 调用点已存在 TTL 行为
- [ ] message 服务初始化时调用 \`SeqGen::backfill_session/user\` 从 DB 回填
- [ ] 验证 DLX 命名变更后没有遗留旧名称（生产环境需要先清旧队列）