### PR TITLE
feat: cache infrastructure redesign — Redis Cluster + L1 cache + layered locks

### DIFF
--- a/common/auth/jwt_store.hpp
+++ b/common/auth/jwt_store.hpp
@@ -15,8 +15,7 @@
  */
 
 #include "infra/logger.hpp"
-
-#include <sw/redis++/redis++.h>
+#include "dao/data_redis.hpp"
 
 #include <chrono>
 #include <memory>
@@ -33,7 +32,7 @@ inline constexpr const char* kRtChainPrefix  = "im:jwt:rt_chain:";
 class JwtStore {
 public:
     using ptr = std::shared_ptr<JwtStore>;
-    explicit JwtStore(std::shared_ptr<sw::redis::Redis> c) : _c(std::move(c)) {}
+    explicit JwtStore(chatnow::RedisClient::ptr c) : _c(std::move(c)) {}
 
     void revoke(const std::string& jti, int ttl_sec);
     bool is_revoked(const std::string& jti);
@@ -64,7 +63,7 @@ public:
                                                 int new_refresh_ttl_sec);
 
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    chatnow::RedisClient::ptr _c;
 
     static constexpr int kChainTtlSec = 24 * 3600;
 };

--- a/common/dao/data_redis.hpp
+++ b/common/dao/data_redis.hpp
@@ -55,6 +55,14 @@ public:
              std::chrono::milliseconds ttl) {
         return _rc ? _rc->set(key, val, ttl) : _r->set(key, val, ttl);
     }
+    bool set(const std::string &key, const std::string &val,
+             std::chrono::seconds ttl, sw::redis::UpdateType type) {
+        return _rc ? _rc->set(key, val, ttl, type) : _r->set(key, val, ttl, type);
+    }
+    bool set(const std::string &key, const std::string &val,
+             std::chrono::milliseconds ttl, sw::redis::UpdateType type) {
+        return _rc ? _rc->set(key, val, ttl, type) : _r->set(key, val, ttl, type);
+    }
     long long del(const std::string &key) {
         return _rc ? _rc->del(key) : _r->del(key);
     }

--- a/common/dao/data_redis.hpp
+++ b/common/dao/data_redis.hpp
@@ -18,8 +18,10 @@
  */
 
 #include <sw/redis++/redis++.h>
+#include <sw/redis++/redis_cluster.h>
 #include <chrono>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -27,6 +29,139 @@
 
 namespace chatnow
 {
+
+// 类型擦除 Redis 客户端适配器：根据持有的后端类型透明转发到
+// sw::redis::Redis（单机）或 sw::redis::RedisCluster。所有 cache 类
+// 统一使用 RedisClient::ptr，对调用方完全透明。每次调用一次分支
+// 判断（~1ns）相对 Redis 网络延迟（~0.5ms）可忽略。
+class RedisClient
+{
+public:
+    using ptr = std::shared_ptr<RedisClient>;
+
+    RedisClient(std::shared_ptr<sw::redis::Redis> r) : _r(std::move(r)) {}
+    RedisClient(std::shared_ptr<sw::redis::RedisCluster> rc) : _rc(std::move(rc)) {}
+
+    // --- String commands ---
+    sw::redis::OptionalString get(const std::string &key) {
+        return _rc ? _rc->get(key) : _r->get(key);
+    }
+    bool set(const std::string &key, const std::string &val,
+             std::chrono::seconds ttl = std::chrono::seconds(0)) {
+        return _rc ? _rc->set(key, val, ttl) : _r->set(key, val, ttl);
+    }
+    bool set(const std::string &key, const std::string &val,
+             std::chrono::milliseconds ttl) {
+        return _rc ? _rc->set(key, val, ttl) : _r->set(key, val, ttl);
+    }
+    long long del(const std::string &key) {
+        return _rc ? _rc->del(key) : _r->del(key);
+    }
+    void expire(const std::string &key, std::chrono::seconds ttl) {
+        _rc ? _rc->expire(key, ttl) : _r->expire(key, ttl);
+    }
+    long long incr(const std::string &key) {
+        return _rc ? _rc->incr(key) : _r->incr(key);
+    }
+
+    // --- Set commands ---
+    template <typename T>
+    long long sadd(const std::string &key, const T &member) {
+        return _rc ? _rc->sadd(key, member) : _r->sadd(key, member);
+    }
+    template <typename It>
+    long long sadd(const std::string &key, It first, It last) {
+        return _rc ? _rc->sadd(key, first, last) : _r->sadd(key, first, last);
+    }
+    template <typename Out>
+    void smembers(const std::string &key, Out out) {
+        _rc ? _rc->smembers(key, out) : _r->smembers(key, out);
+    }
+    template <typename T>
+    long long srem(const std::string &key, const T &member) {
+        return _rc ? _rc->srem(key, member) : _r->srem(key, member);
+    }
+    long long scard(const std::string &key) {
+        return _rc ? _rc->scard(key) : _r->scard(key);
+    }
+
+    // --- Hash commands ---
+    long long hset(const std::string &key, const std::string &field, const std::string &val) {
+        return _rc ? _rc->hset(key, field, val) : _r->hset(key, field, val);
+    }
+    sw::redis::OptionalString hget(const std::string &key, const std::string &field) {
+        return _rc ? _rc->hget(key, field) : _r->hget(key, field);
+    }
+    long long hdel(const std::string &key, const std::string &field) {
+        return _rc ? _rc->hdel(key, field) : _r->hdel(key, field);
+    }
+    template <typename Out>
+    void hkeys(const std::string &key, Out out) {
+        _rc ? _rc->hkeys(key, out) : _r->hkeys(key, out);
+    }
+    template <typename Out>
+    void hgetall(const std::string &key, Out out) {
+        _rc ? _rc->hgetall(key, out) : _r->hgetall(key, out);
+    }
+    long long hlen(const std::string &key) {
+        return _rc ? _rc->hlen(key) : _r->hlen(key);
+    }
+
+    // --- Sorted Set commands ---
+    long long zadd(const std::string &key, const std::string &member, double score) {
+        return _rc ? _rc->zadd(key, member, score) : _r->zadd(key, member, score);
+    }
+    long long zadd(const std::string &key, const std::string &member, double score,
+                   sw::redis::UpdateType type) {
+        return _rc ? _rc->zadd(key, member, score, type) : _r->zadd(key, member, score, type);
+    }
+    long long zrem(const std::string &key, const std::string &member) {
+        return _rc ? _rc->zrem(key, member) : _r->zrem(key, member);
+    }
+    template <typename Out>
+    void zrange(const std::string &key, long long start, long long stop, Out out) {
+        _rc ? _rc->zrange(key, start, stop, out) : _r->zrange(key, start, stop, out);
+    }
+    template <typename Out>
+    void zrangebyscore(const std::string &key,
+                       const sw::redis::BoundedInterval<double> &interval,
+                       const sw::redis::LimitOptions &opts, Out out) {
+        _rc ? _rc->zrangebyscore(key, interval, opts, out)
+            : _r->zrangebyscore(key, interval, opts, out);
+    }
+
+    // --- Lua scripting ---
+    template <typename Ret, typename KeyIt, typename ArgIt>
+    Ret eval(const std::string &script, KeyIt key_first, KeyIt key_last,
+             ArgIt arg_first, ArgIt arg_last) {
+        return _rc ? _rc->eval<Ret>(script, key_first, key_last, arg_first, arg_last)
+                   : _r->eval<Ret>(script, key_first, key_last, arg_first, arg_last);
+    }
+    template <typename Ret, typename KeyIt, typename ArgIt, typename Out>
+    Ret eval(const std::string &script, KeyIt key_first, KeyIt key_last,
+             ArgIt arg_first, ArgIt arg_last, Out out) {
+        return _rc ? _rc->eval<Ret>(script, key_first, key_last, arg_first, arg_last, out)
+                   : _r->eval<Ret>(script, key_first, key_last, arg_first, arg_last, out);
+    }
+
+    // --- Pipeline ---
+    auto pipeline() {
+        return _rc ? _rc->pipeline() : _r->pipeline();
+    }
+
+    // --- SCAN ---
+    template <typename Out>
+    long long scan(long long cursor, const std::string &pattern, long long count, Out out) {
+        return _rc ? _rc->scan(cursor, pattern, count, out)
+                   : _r->scan(cursor, pattern, count, out);
+    }
+
+    bool is_cluster() const { return _rc != nullptr; }
+
+private:
+    std::shared_ptr<sw::redis::Redis> _r;
+    std::shared_ptr<sw::redis::RedisCluster> _rc;
+};
 
 namespace key
 {
@@ -94,6 +229,64 @@ public:
     }
 };
 
+/* brief: Redis Cluster 工厂 — 通过种子节点自动发现集群拓扑 */
+class RedisClusterFactory
+{
+public:
+    static std::shared_ptr<sw::redis::RedisCluster> create(
+        const std::string &seed_nodes_csv,  // "host1:6379,host2:6379,host3:6379"
+        int pool_size = 16,
+        bool keep_alive = true)
+    {
+        // 解析所有种子节点
+        std::vector<std::pair<std::string, uint16_t>> seeds;
+        {
+            std::istringstream ss(seed_nodes_csv);
+            std::string token;
+            while (std::getline(ss, token, ',')) {
+                auto colon = token.find(':');
+                if (colon == std::string::npos) continue;
+                seeds.emplace_back(
+                    token.substr(0, colon),
+                    static_cast<uint16_t>(std::stoi(token.substr(colon + 1))));
+            }
+        }
+        if (seeds.empty()) {
+            throw std::runtime_error("RedisClusterFactory: 无有效种子节点");
+        }
+
+        sw::redis::ConnectionPoolOptions popts;
+        popts.size = pool_size;
+        popts.wait_timeout = std::chrono::milliseconds(500);
+        popts.connection_lifetime = std::chrono::minutes(30);
+
+        // 逐个尝试种子节点，直到成功连接（sw::redis++ RedisCluster 仅需一个种子
+        // 即可通过 CLUSTER SLOTS 自动发现完整拓扑）
+        std::string last_error;
+        for (const auto &[host, port] : seeds) {
+            try {
+                sw::redis::ConnectionOptions copts;
+                copts.host = host;
+                copts.port = port;
+                copts.keep_alive = keep_alive;
+                copts.connect_timeout = std::chrono::milliseconds(2000);
+                copts.socket_timeout  = std::chrono::milliseconds(2000);
+
+                auto cluster = std::make_shared<sw::redis::RedisCluster>(copts, popts);
+                // 验证连接可用（立即尝试一个轻量命令）
+                cluster->ping("cluster-seed-check");
+                LOG_INFO("RedisClusterFactory: 通过种子 {}:{} 成功连接集群", host, port);
+                return cluster;
+            } catch (std::exception &e) {
+                last_error = e.what();
+                LOG_WARN("RedisClusterFactory: 种子 {}:{} 连接失败 ({}), 尝试下一个",
+                         host, port, last_error);
+            }
+        }
+        throw std::runtime_error("RedisClusterFactory: 所有种子节点连接失败 — " + last_error);
+    }
+};
+
 // =============================================================================
 // 登录态 / 在线态 / 验证码（沿用旧 API，但补齐 TTL）
 // =============================================================================
@@ -102,7 +295,7 @@ class Session
 {
 public:
     using ptr = std::shared_ptr<Session>;
-    Session(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    Session(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 写入登录态，TTL 7 天 */
     void append(const std::string &ssid, const std::string &uid,
@@ -124,14 +317,14 @@ public:
         catch(std::exception &e) { LOG_ERROR("Session.touch 失败 {}: {}", ssid, e.what()); }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 class Status
 {
 public:
     using ptr = std::shared_ptr<Status>;
-    Status(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    Status(const RedisClient::ptr &c) : _c(c) {}
     void append(const std::string &uid, std::chrono::seconds ttl = kStatusTtl) {
         try { _c->set(key::kStatus + uid, "1", ttl); }
         catch(std::exception &e) { LOG_ERROR("Status.append 失败 {}: {}", uid, e.what()); }
@@ -150,14 +343,14 @@ public:
         catch(std::exception &e) { LOG_ERROR("Status.touch 失败 {}: {}", uid, e.what()); }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 class Codes
 {
 public:
     using ptr = std::shared_ptr<Codes>;
-    Codes(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    Codes(const RedisClient::ptr &c) : _c(c) {}
     void append(const std::string &cid, const std::string &code,
                 std::chrono::seconds ttl = kCodeTtl) {
         try { _c->set(key::kVerifyCode + cid, code, ttl); }
@@ -172,7 +365,7 @@ public:
         catch(std::exception &e) { LOG_ERROR("Codes.code 失败 {}: {}", cid, e.what()); return {}; }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -198,7 +391,7 @@ class SeqGen
 {
 public:
     using ptr = std::shared_ptr<SeqGen>;
-    SeqGen(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    SeqGen(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 申请一个会话级 seq；失败返回 0（业务侧需视为 fatal） */
     unsigned long next_session_seq(const std::string &ssid) {
@@ -267,7 +460,7 @@ private:
         "    return 1 "
         "end "
         "return 0";
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -278,7 +471,7 @@ class LastMessage
 {
 public:
     using ptr = std::shared_ptr<LastMessage>;
-    LastMessage(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    LastMessage(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 写最后一条消息预览（已序列化 JSON 字符串）；TTL 24h */
     void set(const std::string &ssid, const std::string &preview_json,
@@ -295,7 +488,7 @@ public:
         catch(std::exception &e) { LOG_ERROR("LastMessage.del 失败 {}: {}", ssid, e.what()); }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -306,7 +499,7 @@ class DeviceSet
 {
 public:
     using ptr = std::shared_ptr<DeviceSet>;
-    DeviceSet(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    DeviceSet(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 用户某设备上线 */
     void add(const std::string &uid, const std::string &device_id) {
@@ -331,7 +524,7 @@ public:
         catch(std::exception &e) { LOG_ERROR("DeviceSet.any 失败 {}: {}", uid, e.what()); return false; }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -342,7 +535,7 @@ class ReadAck
 {
 public:
     using ptr = std::shared_ptr<ReadAck>;
-    ReadAck(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    ReadAck(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 用户对消息已读，幂等添加到 SET */
     void ack(unsigned long message_id, const std::string &uid,
@@ -380,7 +573,7 @@ public:
         return res;
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -391,7 +584,7 @@ class Members
 {
 public:
     using ptr = std::shared_ptr<Members>;
-    Members(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    Members(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 取群成员列表；空返回 → 调用方回查 RPC + warm() */
     std::vector<std::string> list(const std::string &ssid) {
@@ -427,7 +620,7 @@ public:
         catch(std::exception &e) { LOG_ERROR("Members.invalidate 失败 {}: {}", ssid, e.what()); }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -438,7 +631,7 @@ class OnlineRoute
 {
 public:
     using ptr = std::shared_ptr<OnlineRoute>;
-    OnlineRoute(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    OnlineRoute(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 设备上线 — HSET uid did instance */
     void bind(const std::string &uid, const std::string &device_id,
@@ -487,7 +680,7 @@ public:
         catch(std::exception &e) { LOG_ERROR("OnlineRoute.online 失败 {}: {}", uid, e.what()); return false; }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -498,7 +691,7 @@ class RateLimiter
 {
 public:
     using ptr = std::shared_ptr<RateLimiter>;
-    RateLimiter(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    RateLimiter(const RedisClient::ptr &c) : _c(c) {}
 
     /**
      * brief: 滑动窗口 incr-and-check
@@ -523,7 +716,7 @@ public:
         return allow(key::kRateSsid + ssid, max_count, window_sec);
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -534,7 +727,7 @@ class PushOutbox
 {
 public:
     using ptr = std::shared_ptr<PushOutbox>;
-    PushOutbox(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    PushOutbox(const RedisClient::ptr &c) : _c(c) {}
 
     /* brief: 投递失败入队（payload 是 InternalMessage 序列化后的 binary） */
     void enqueue(const std::string &payload, long long score_ts) {
@@ -595,7 +788,7 @@ public:
         }
     }
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -606,7 +799,7 @@ class CrossInstanceOutbox
 {
 public:
     using ptr = std::shared_ptr<CrossInstanceOutbox>;
-    CrossInstanceOutbox(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    CrossInstanceOutbox(const RedisClient::ptr &c) : _c(c) {}
 
     void enqueue(const std::string &payload_b64,
                  const std::vector<std::string> &failed_uids,
@@ -676,7 +869,7 @@ public:
     }
 
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -687,7 +880,7 @@ class ESOutbox
 {
 public:
     using ptr = std::shared_ptr<ESOutbox>;
-    ESOutbox(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    ESOutbox(const RedisClient::ptr &c) : _c(c) {}
 
     void enqueue(const std::string &payload, long long score_ts) {
         try { _c->zadd(kEsOutboxKey, payload, static_cast<double>(score_ts)); }
@@ -742,7 +935,7 @@ public:
     }
 
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
     static constexpr const char *kEsOutboxKey     = "im:es:outbox";
     static constexpr const char *kEsOutboxLockKey = "im:es:outbox:lock";
 };
@@ -755,7 +948,7 @@ class UnackedPush
 {
 public:
     using ptr = std::shared_ptr<UnackedPush>;
-    UnackedPush(const std::shared_ptr<sw::redis::Redis> &c) : _c(c) {}
+    UnackedPush(const RedisClient::ptr &c) : _c(c) {}
 
     static std::string key_for(const std::string &uid, const std::string &device_id) {
         return std::string(key::kUnacked) + uid + ":" + device_id;
@@ -847,7 +1040,7 @@ public:
     }
 
 private:
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
 };
 
 // =============================================================================
@@ -858,7 +1051,7 @@ class PresenceRedis
 {
 public:
     using ptr = std::shared_ptr<PresenceRedis>;
-    PresenceRedis(const std::shared_ptr<sw::redis::Redis> &r) : _r(r) {}
+    PresenceRedis(const RedisClient::ptr &r) : _r(r) {}
 
     /* 设置状态 */
     void set_state(const std::string &uid, const std::string &state) {
@@ -922,7 +1115,7 @@ public:
     }
 
 private:
-    std::shared_ptr<sw::redis::Redis> _r;
+    RedisClient::ptr _r;
 };
 
 } // namespace chatnow

--- a/common/dao/data_redis.hpp
+++ b/common/dao/data_redis.hpp
@@ -189,9 +189,7 @@ namespace key
     inline constexpr const char* kPushRoute  = "im:push:route:";    // uid        -> push_instance_id (单设备)
     inline constexpr const char* kUnacked    = "im:unack:";         // uid        -> Sorted Set<msg_id, ts>
     inline constexpr const char* kPushOutbox     = "im:push:outbox";       // 全局 Sorted Set<serialized_payload, ts> 投递失败兜底
-    inline constexpr const char* kPushOutboxLock = "im:push:outbox:lock";  // M3 reaper 单实例租约 key
     inline constexpr const char* kCrossOutbox     = "im:push:cross_outbox";
-    inline constexpr const char* kCrossOutboxLock = "im:push:cross_outbox:lock";
 
     // --- Presence 域（Push 内模块） ---
     inline constexpr const char* kPresence        = "im:presence:";         // {uid} → HASH {state,last_active,custom_status}
@@ -766,47 +764,6 @@ public:
         try { _c->zrem(key::kPushOutbox, payload); }
         catch(std::exception &e) { LOG_ERROR("PushOutbox.remove 失败: {}", e.what()); }
     }
-
-    /* brief: M3 reaper 单实例租约 — SET NX EX 上锁；已持有则原子续约。
-     *        必须 Lua 原子，否则 acquire 的 GET+EXPIRE 与 release 的 GET+DEL 都有 TOCTOU race，
-     *        race 下两个实例可能同时认为自己持锁，导致 outbox 双发。
-     *        返回是否拿到 / 续到锁。
-     */
-    bool try_acquire_reaper_lease(const std::string &owner, int ttl_sec) {
-        static const char *kAcquireLua =
-            "if redis.call('SET', KEYS[1], ARGV[1], 'NX', 'EX', ARGV[2]) then return 1 end "
-            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
-            "    redis.call('EXPIRE', KEYS[1], ARGV[2]); return 1 "
-            "end "
-            "return 0";
-        try {
-            std::vector<std::string> keys = {key::kPushOutboxLock};
-            std::vector<std::string> args = {owner, std::to_string(ttl_sec)};
-            auto ret = _c->eval<long long>(kAcquireLua, keys.begin(), keys.end(),
-                                           args.begin(), args.end());
-            return ret == 1;
-        } catch(std::exception &e) {
-            LOG_ERROR("PushOutbox.try_acquire_reaper_lease 失败: {}", e.what());
-            return false;
-        }
-    }
-
-    /* brief: M3 reaper 主动释放租约（CAS：仅 owner 与自己一致时 DEL，原子） */
-    void release_reaper_lease(const std::string &owner) {
-        static const char *kReleaseLua =
-            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
-            "    return redis.call('DEL', KEYS[1]) "
-            "end "
-            "return 0";
-        try {
-            std::vector<std::string> keys = {key::kPushOutboxLock};
-            std::vector<std::string> args = {owner};
-            _c->eval<long long>(kReleaseLua, keys.begin(), keys.end(),
-                                args.begin(), args.end());
-        } catch(std::exception &e) {
-            LOG_ERROR("PushOutbox.release_reaper_lease 失败: {}", e.what());
-        }
-    }
 private:
     RedisClient::ptr _c;
 };
@@ -853,41 +810,6 @@ public:
         catch(std::exception &e) { LOG_ERROR("CrossInstanceOutbox.remove 失败: {}", e.what()); }
     }
 
-    bool try_acquire_reaper_lease(const std::string &owner, int ttl_sec) {
-        static const char *kAcquireLua =
-            "if redis.call('SET', KEYS[1], ARGV[1], 'NX', 'EX', ARGV[2]) then return 1 end "
-            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
-            "    redis.call('EXPIRE', KEYS[1], ARGV[2]); return 1 "
-            "end "
-            "return 0";
-        try {
-            std::vector<std::string> keys = {key::kCrossOutboxLock};
-            std::vector<std::string> args = {owner, std::to_string(ttl_sec)};
-            auto ret = _c->eval<long long>(kAcquireLua, keys.begin(), keys.end(),
-                                           args.begin(), args.end());
-            return ret == 1;
-        } catch(std::exception &e) {
-            LOG_ERROR("CrossInstanceOutbox.try_acquire_reaper_lease 失败: {}", e.what());
-            return false;
-        }
-    }
-
-    void release_reaper_lease(const std::string &owner) {
-        static const char *kReleaseLua =
-            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
-            "    return redis.call('DEL', KEYS[1]) "
-            "end "
-            "return 0";
-        try {
-            std::vector<std::string> keys = {key::kCrossOutboxLock};
-            std::vector<std::string> args = {owner};
-            _c->eval<long long>(kReleaseLua, keys.begin(), keys.end(),
-                                args.begin(), args.end());
-        } catch(std::exception &e) {
-            LOG_ERROR("CrossInstanceOutbox.release_reaper_lease 失败: {}", e.what());
-        }
-    }
-
 private:
     RedisClient::ptr _c;
 };
@@ -920,44 +842,9 @@ public:
         catch(std::exception &e) { LOG_ERROR("ESOutbox.remove 失败: {}", e.what()); }
     }
 
-    bool try_acquire_reaper_lease(const std::string &owner, int ttl_sec) {
-        static const char *kAcquireLua =
-            "if redis.call('SET', KEYS[1], ARGV[1], 'NX', 'EX', ARGV[2]) then return 1 end "
-            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
-            "    redis.call('EXPIRE', KEYS[1], ARGV[2]); return 1 "
-            "end "
-            "return 0";
-        try {
-            std::vector<std::string> keys = {kEsOutboxLockKey};
-            std::vector<std::string> args = {owner, std::to_string(ttl_sec)};
-            return _c->eval<long long>(kAcquireLua, keys.begin(), keys.end(),
-                                        args.begin(), args.end()) == 1;
-        } catch(std::exception &e) {
-            LOG_ERROR("ESOutbox.try_acquire_reaper_lease 失败: {}", e.what());
-            return false;
-        }
-    }
-
-    void release_reaper_lease(const std::string &owner) {
-        static const char *kReleaseLua =
-            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
-            "    return redis.call('DEL', KEYS[1]) "
-            "end "
-            "return 0";
-        try {
-            std::vector<std::string> keys = {kEsOutboxLockKey};
-            std::vector<std::string> args = {owner};
-            _c->eval<long long>(kReleaseLua, keys.begin(), keys.end(),
-                                args.begin(), args.end());
-        } catch(std::exception &e) {
-            LOG_ERROR("ESOutbox.release_reaper_lease 失败: {}", e.what());
-        }
-    }
-
 private:
     RedisClient::ptr _c;
     static constexpr const char *kEsOutboxKey     = "im:es:outbox";
-    static constexpr const char *kEsOutboxLockKey = "im:es:outbox:lock";
 };
 
 // =============================================================================

--- a/common/dao/data_redis.hpp
+++ b/common/dao/data_redis.hpp
@@ -26,6 +26,7 @@
 #include <unordered_set>
 #include <vector>
 #include "infra/logger.hpp"
+#include "utils/random_ttl.hpp"
 
 namespace chatnow
 {
@@ -198,7 +199,7 @@ inline constexpr std::chrono::seconds kCodeTtl(60 * 5);             // 验证码
 inline constexpr std::chrono::seconds kLastMsgTtl(24 * 3600);       // 最近消息预览 24 小时
 inline constexpr std::chrono::seconds kReadAckTtl(24 * 3600);       // 已读暂存 24 小时
 inline constexpr std::chrono::seconds kMembersTtl(30 * 60);         // 成员缓存 30 分钟
-inline constexpr std::chrono::seconds kOnlineTtl(120);              // 在线路由 120s（依赖心跳续期）
+inline constexpr std::chrono::seconds kOnlineTtl(30);               // 在线路由 30s（依赖心跳续期，每 heartbeat 刷新）
 inline constexpr std::chrono::seconds kUnackedTtl(7 * 24 * 3600);   // 未 ack 重传缓冲 7 天
 
 
@@ -476,7 +477,7 @@ public:
     /* brief: 写最后一条消息预览（已序列化 JSON 字符串）；TTL 24h */
     void set(const std::string &ssid, const std::string &preview_json,
              std::chrono::seconds ttl = kLastMsgTtl) {
-        try { _c->set(key::kLastMsg + ssid, preview_json, ttl); }
+        try { _c->set(key::kLastMsg + ssid, preview_json, randomized_ttl(ttl)); }
         catch(std::exception &e) { LOG_ERROR("LastMessage.set 失败 {}: {}", ssid, e.what()); }
     }
     sw::redis::OptionalString get(const std::string &ssid) {
@@ -543,7 +544,7 @@ public:
         try {
             std::string k = key::kReadAck + std::to_string(message_id);
             _c->sadd(k, uid);
-            _c->expire(k, ttl);
+            _c->expire(k, randomized_ttl(ttl));
         } catch(std::exception &e) {
             LOG_ERROR("ReadAck.ack 失败 mid={} uid={}: {}", message_id, uid, e.what());
         }
@@ -600,7 +601,7 @@ public:
         try {
             std::string k = key::kMembers + ssid;
             _c->sadd(k, uids.begin(), uids.end());
-            _c->expire(k, ttl);
+            _c->expire(k, randomized_ttl(ttl));
         } catch(std::exception &e) {
             LOG_ERROR("Members.warm 失败 {}: {}", ssid, e.what());
         }
@@ -618,6 +619,17 @@ public:
     void invalidate(const std::string &ssid) {
         try { _c->del(key::kMembers + ssid); }
         catch(std::exception &e) { LOG_ERROR("Members.invalidate 失败 {}: {}", ssid, e.what()); }
+    }
+    void touch_ttl(const std::string &ssid, std::chrono::seconds ttl = kMembersTtl) {
+        try { _c->expire(key::kMembers + ssid, randomized_ttl(ttl)); }
+        catch (std::exception &e) { LOG_ERROR("Members.touch_ttl 失败 {}: {}", ssid, e.what()); }
+    }
+    void warm_sentinel(const std::string &ssid, std::chrono::seconds ttl = std::chrono::seconds(60)) {
+        try {
+            std::string k = key::kMembers + ssid;
+            _c->sadd(k, "__sentinel__");
+            _c->expire(k, randomized_ttl(ttl));
+        } catch (std::exception &e) { LOG_ERROR("Members.warm_sentinel 失败 {}: {}", ssid, e.what()); }
     }
 private:
     RedisClient::ptr _c;
@@ -640,14 +652,14 @@ public:
         try {
             std::string k = key::kOnline + uid;
             _c->hset(k, device_id, push_instance);
-            _c->expire(k, ttl);
+            _c->expire(k, randomized_ttl(ttl));
         } catch(std::exception &e) {
             LOG_ERROR("OnlineRoute.bind 失败 {}-{}-{}: {}", uid, device_id, push_instance, e.what());
         }
     }
     /* brief: 心跳续期（续整个 uid 的 HASH） */
     void touch(const std::string &uid, std::chrono::seconds ttl = kOnlineTtl) {
-        try { _c->expire(key::kOnline + uid, ttl); }
+        try { _c->expire(key::kOnline + uid, randomized_ttl(ttl)); }
         catch(std::exception &e) { LOG_ERROR("OnlineRoute.touch 失败 {}: {}", uid, e.what()); }
     }
     /* brief: 设备下线 — HDEL uid did */

--- a/common/infra/leader_election.hpp
+++ b/common/infra/leader_election.hpp
@@ -5,16 +5,16 @@
 #include <etcd/Transaction.hpp>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include "infra/logger.hpp"
 
 namespace chatnow {
 
-// etcd Lease + Transaction CAS 选举锁。
-// 使用 etcdv3 Transaction 保证"仅当 key 不存在时才写入"，消除双主窗口。
 class LeaderElection {
 public:
     using ptr = std::shared_ptr<LeaderElection>;
@@ -38,6 +38,7 @@ public:
 
     void stop() {
         _running = false;
+        _cv.notify_all();
         if (_keep_alive) {
             try { _keep_alive->Cancel(); } catch (...) {}
         }
@@ -53,12 +54,11 @@ private:
                 auto lease_resp = _etcd->leasegrant(_ttl).get();
                 if (!lease_resp.is_ok()) {
                     LOG_WARN("LeaderElection leasegrant 失败: {}", lease_resp.error_message());
-                    std::this_thread::sleep_for(std::chrono::seconds(_ttl / 2));
+                    if (!_sleep_interruptible_(std::chrono::seconds(_ttl / 2))) return;
                     continue;
                 }
                 int64_t lease_id = lease_resp.value().lease();
 
-                // Transaction CAS: compare version(key) == 0 → key 不存在则写入
                 etcd::Transaction txn;
                 txn.setup_compare_version(_key, etcd::CompareResult::EQUAL, 0);
                 txn.setup_put_success(_key, _id, lease_id);
@@ -84,21 +84,24 @@ private:
                 LOG_ERROR("LeaderElection campaign 异常: {}", e.what());
             }
 
-            if (_running) {
-                std::this_thread::sleep_for(std::chrono::seconds(_ttl / 3));
-            }
+            if (!_sleep_interruptible_(std::chrono::seconds(_ttl / 3))) return;
         }
     }
 
     void _hold_leadership_(int64_t lease_id) {
         while (_running && _is_leader) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            if (!_sleep_interruptible_(std::chrono::seconds(1))) return;
             auto ttl_resp = _etcd->timetolive(lease_id).get();
             if (!ttl_resp.is_ok() || ttl_resp.value().ttl() <= 0) {
                 LOG_WARN("LeaderElection lease {} 过期，失去 leader", lease_id);
                 break;
             }
         }
+    }
+
+    bool _sleep_interruptible_(std::chrono::seconds duration) {
+        std::unique_lock<std::mutex> lk(_cv_mu);
+        return !_cv.wait_for(lk, duration, [this] { return !_running; });
     }
 
     std::shared_ptr<etcd::Client> _etcd;
@@ -112,6 +115,9 @@ private:
     std::atomic<bool> _running{false};
     std::atomic<bool> _is_leader{false};
     std::shared_ptr<etcd::KeepAlive> _keep_alive;
+
+    std::mutex _cv_mu;
+    std::condition_variable _cv;
 };
 
 } // namespace chatnow

--- a/common/infra/leader_election.hpp
+++ b/common/infra/leader_election.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <etcd/Client.hpp>
+#include <etcd/KeepAlive.hpp>
+#include <etcd/Transaction.hpp>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include "infra/logger.hpp"
+
+namespace chatnow {
+
+// etcd Lease + Transaction CAS 选举锁。
+// 使用 etcdv3 Transaction 保证"仅当 key 不存在时才写入"，消除双主窗口。
+class LeaderElection {
+public:
+    using ptr = std::shared_ptr<LeaderElection>;
+
+    LeaderElection(std::shared_ptr<etcd::Client> etcd,
+                   const std::string &election_key,
+                   const std::string &instance_id,
+                   int lease_ttl_sec,
+                   std::function<void()> on_acquired,
+                   std::function<void()> on_lost)
+        : _etcd(std::move(etcd)), _key(election_key), _id(instance_id),
+          _ttl(lease_ttl_sec), _on_acquired(std::move(on_acquired)),
+          _on_lost(std::move(on_lost)) {}
+
+    ~LeaderElection() { stop(); }
+
+    void start() {
+        _running = true;
+        _thread = std::thread([this]() { campaign_loop_(); });
+    }
+
+    void stop() {
+        _running = false;
+        if (_keep_alive) {
+            try { _keep_alive->Cancel(); } catch (...) {}
+        }
+        if (_thread.joinable()) _thread.join();
+    }
+
+    bool is_leader() const { return _is_leader.load(); }
+
+private:
+    void campaign_loop_() {
+        while (_running) {
+            try {
+                auto lease_resp = _etcd->leasegrant(_ttl).get();
+                if (!lease_resp.is_ok()) {
+                    LOG_WARN("LeaderElection leasegrant 失败: {}", lease_resp.error_message());
+                    std::this_thread::sleep_for(std::chrono::seconds(_ttl / 2));
+                    continue;
+                }
+                int64_t lease_id = lease_resp.value().lease();
+
+                // Transaction CAS: compare version(key) == 0 → key 不存在则写入
+                etcd::Transaction txn;
+                txn.setup_compare_version(_key, etcd::CompareResult::EQUAL, 0);
+                txn.setup_put_success(_key, _id, lease_id);
+                txn.setup_get_failure(_key);
+                auto txn_resp = _etcd->txn(txn).get();
+
+                if (txn_resp.is_ok() && txn_resp.value().succeeded()) {
+                    _keep_alive = _etcd->keepalive(lease_id).get();
+                    _is_leader = true;
+                    if (_on_acquired) _on_acquired();
+
+                    _hold_leadership_(lease_id);
+
+                    if (_is_leader.exchange(false)) {
+                        try { _keep_alive->Cancel(); } catch (...) {}
+                        if (_on_lost) _on_lost();
+                    }
+                } else {
+                    LOG_DEBUG("LeaderElection: {} 已被占用，等待重试", _key);
+                    try { _etcd->leaserevoke(lease_id).wait(); } catch (...) {}
+                }
+            } catch (std::exception &e) {
+                LOG_ERROR("LeaderElection campaign 异常: {}", e.what());
+            }
+
+            if (_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(_ttl / 3));
+            }
+        }
+    }
+
+    void _hold_leadership_(int64_t lease_id) {
+        while (_running && _is_leader) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            auto ttl_resp = _etcd->timetolive(lease_id).get();
+            if (!ttl_resp.is_ok() || ttl_resp.value().ttl() <= 0) {
+                LOG_WARN("LeaderElection lease {} 过期，失去 leader", lease_id);
+                break;
+            }
+        }
+    }
+
+    std::shared_ptr<etcd::Client> _etcd;
+    std::string _key;
+    std::string _id;
+    int _ttl;
+    std::function<void()> _on_acquired;
+    std::function<void()> _on_lost;
+
+    std::thread _thread;
+    std::atomic<bool> _running{false};
+    std::atomic<bool> _is_leader{false};
+    std::shared_ptr<etcd::KeepAlive> _keep_alive;
+};
+
+} // namespace chatnow

--- a/common/infra/snowflake.hpp
+++ b/common/infra/snowflake.hpp
@@ -140,12 +140,17 @@ public:
             auto election = std::make_shared<LeaderElection>(
                 _etcd, key, instance_id, lease_ttl, nullptr, nullptr);
             election->start();
-            std::this_thread::sleep_for(std::chrono::milliseconds(200));
-            if (election->is_leader()) {
-                _active_election = election;
-                _allocated = slot;
-                LOG_INFO("EtcdWorkIdAllocator: 申请到 worker_id={}", slot);
-                return slot;
+
+            auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+            while (std::chrono::steady_clock::now() < deadline) {
+                if (election->is_leader()) {
+                    _active_election = election;
+                    _allocated = slot;
+                    LOG_INFO("EtcdWorkIdAllocator: 申请到 worker_id={}", slot);
+                    return slot;
+                }
+                if (!election->is_leader()) break;  // lost immediately
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
             }
             election->stop();
         }

--- a/common/infra/snowflake.hpp
+++ b/common/infra/snowflake.hpp
@@ -28,6 +28,8 @@
 #include <stdexcept>
 #include <thread>
 
+#include "infra/leader_election.hpp"
+
 namespace chatnow
 {
 
@@ -121,6 +123,50 @@ private:
     std::mutex mu_;
     uint64_t   last_ts_  = 0;
     uint64_t   sequence_ = 0;
+};
+
+// etcd-based worker_id allocator: each slot (0-1023) maps to an etcd key
+// /chatnow/snowflake/worker/{id}. Campaign on slot 0 first; if taken, try next.
+class EtcdWorkIdAllocator {
+public:
+    using ptr = std::shared_ptr<EtcdWorkIdAllocator>;
+
+    EtcdWorkIdAllocator(std::shared_ptr<etcd::Client> etcd, int max_workers = 1024)
+        : _etcd(std::move(etcd)), _max_workers(max_workers) {}
+
+    int acquire(const std::string &instance_id, int fallback_worker_id, int lease_ttl = 60) {
+        for (int slot = 0; slot < _max_workers; ++slot) {
+            auto key = "/chatnow/snowflake/worker/" + std::to_string(slot);
+            auto election = std::make_shared<LeaderElection>(
+                _etcd, key, instance_id, lease_ttl, nullptr, nullptr);
+            election->start();
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            if (election->is_leader()) {
+                _active_election = election;
+                _allocated = slot;
+                LOG_INFO("EtcdWorkIdAllocator: 申请到 worker_id={}", slot);
+                return slot;
+            }
+            election->stop();
+        }
+        LOG_ERROR("EtcdWorkIdAllocator: 无可用 worker_id slot，回退到 fallback={}", fallback_worker_id);
+        _allocated = fallback_worker_id;
+        return fallback_worker_id;
+    }
+
+    bool lease_lost() const {
+        return _active_election && !_active_election->is_leader();
+    }
+
+    void deallocate() {
+        if (_active_election) _active_election->stop();
+    }
+
+private:
+    std::shared_ptr<etcd::Client> _etcd;
+    int _max_workers;
+    int _allocated{-1};
+    LeaderElection::ptr _active_election;
 };
 
 } // namespace chatnow

--- a/common/test/test_jwt_store.cc
+++ b/common/test/test_jwt_store.cc
@@ -8,14 +8,14 @@
 #include <thread>
 
 namespace {
-std::shared_ptr<sw::redis::Redis> make_redis() {
+chatnow::RedisClient::ptr make_redis() {
     sw::redis::ConnectionOptions opt;
     opt.host = "127.0.0.1";
     opt.port = 6379;
     opt.db = 15;
     auto c = std::make_shared<sw::redis::Redis>(opt);
     c->flushdb();
-    return c;
+    return std::make_shared<chatnow::RedisClient>(c);
 }
 }  // namespace
 

--- a/common/utils/inflight.hpp
+++ b/common/utils/inflight.hpp
@@ -7,18 +7,40 @@
 
 namespace chatnow {
 
-// 进程内 per-key 互斥注册表：用于合并同一 key 的并发缓存穿透请求。
-// 第一个 miss 的请求 acquire(key) 获取互斥锁，unique_lock 锁定后穿透后端，
-// warm 缓存，然后 release(key)。后续相同 key 的请求 acquire() 拿到同一个
-// mutex，在 unique_lock 上阻塞直到第一个请求完成并 unlock。
 class InflightRegistry {
 public:
     using ptr = std::shared_ptr<InflightRegistry>;
 
-    struct Guard {
+    class Guard {
+    public:
+        Guard() = default;
+        Guard(std::shared_ptr<std::mutex> m, std::string k, InflightRegistry *r)
+            : mu(std::move(m)), key(std::move(k)), registry(r) {}
+
+        ~Guard() { if (registry) registry->release(key); }
+
+        Guard(const Guard &) = delete;
+        Guard &operator=(const Guard &) = delete;
+        Guard(Guard &&o) noexcept
+            : mu(std::move(o.mu)), key(std::move(o.key)), registry(o.registry) {
+            o.registry = nullptr;
+        }
+        Guard &operator=(Guard &&o) noexcept {
+            if (this != &o) {
+                if (registry) registry->release(key);
+                mu = std::move(o.mu);
+                key = std::move(o.key);
+                registry = o.registry;
+                o.registry = nullptr;
+            }
+            return *this;
+        }
+
         std::shared_ptr<std::mutex> mu;
         std::string key;
-        InflightRegistry *registry;
+
+    private:
+        InflightRegistry *registry = nullptr;
     };
 
     Guard acquire(const std::string &key) {

--- a/common/utils/inflight.hpp
+++ b/common/utils/inflight.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace chatnow {
+
+// 进程内 per-key 互斥注册表：用于合并同一 key 的并发缓存穿透请求。
+// 第一个 miss 的请求 acquire(key) 获取互斥锁，unique_lock 锁定后穿透后端，
+// warm 缓存，然后 release(key)。后续相同 key 的请求 acquire() 拿到同一个
+// mutex，在 unique_lock 上阻塞直到第一个请求完成并 unlock。
+class InflightRegistry {
+public:
+    using ptr = std::shared_ptr<InflightRegistry>;
+
+    struct Guard {
+        std::shared_ptr<std::mutex> mu;
+        std::string key;
+        InflightRegistry *registry;
+    };
+
+    Guard acquire(const std::string &key) {
+        std::shared_ptr<std::mutex> mu;
+        {
+            std::lock_guard lk(_mu);
+            auto it = _inflight.find(key);
+            if (it == _inflight.end()) {
+                mu = std::make_shared<std::mutex>();
+                _inflight[key] = mu;
+            } else {
+                mu = it->second;
+            }
+        }
+        return {mu, key, this};
+    }
+
+    void release(const std::string &key) {
+        std::lock_guard lk(_mu);
+        _inflight.erase(key);
+    }
+
+private:
+    std::mutex _mu;
+    std::unordered_map<std::string, std::shared_ptr<std::mutex>> _inflight;
+};
+
+} // namespace chatnow

--- a/common/utils/local_cache.hpp
+++ b/common/utils/local_cache.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <chrono>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+
+namespace chatnow {
+
+// 线程安全的进程内本地缓存。TTL 自动过期（lazy eviction），读写锁保护。
+template <typename V>
+class LocalCache {
+public:
+    using ptr = std::shared_ptr<LocalCache<V>>;
+
+    explicit LocalCache(size_t size_hint = 4096) { _map.reserve(size_hint); }
+
+    std::optional<V> get(const std::string &key) {
+        std::shared_lock lk(_mu);
+        auto it = _map.find(key);
+        if (it == _map.end()) return std::nullopt;
+        if (std::chrono::steady_clock::now() > it->second.expires_at)
+            return std::nullopt;
+        return it->second.value;
+    }
+
+    void set(const std::string &key, const V &value, std::chrono::seconds ttl) {
+        std::unique_lock lk(_mu);
+        _map[key] = {value, std::chrono::steady_clock::now() + ttl};
+    }
+
+    // CAS: 仅当 key 不存在或已过期时设置
+    bool set_if_absent(const std::string &key, const V &value,
+                       std::chrono::seconds ttl) {
+        std::unique_lock lk(_mu);
+        auto it = _map.find(key);
+        if (it != _map.end() &&
+            std::chrono::steady_clock::now() <= it->second.expires_at) {
+            return false;
+        }
+        _map[key] = {value, std::chrono::steady_clock::now() + ttl};
+        return true;
+    }
+
+    void invalidate(const std::string &key) {
+        std::unique_lock lk(_mu);
+        _map.erase(key);
+    }
+
+    size_t size() const {
+        std::shared_lock lk(_mu);
+        return _map.size();
+    }
+
+    size_t evict_expired() {
+        std::unique_lock lk(_mu);
+        auto now = std::chrono::steady_clock::now();
+        size_t removed = 0;
+        for (auto it = _map.begin(); it != _map.end(); ) {
+            if (now > it->second.expires_at) { it = _map.erase(it); ++removed; }
+            else { ++it; }
+        }
+        return removed;
+    }
+
+private:
+    struct Entry {
+        V value;
+        std::chrono::steady_clock::time_point expires_at;
+    };
+    mutable std::shared_mutex _mu;
+    std::unordered_map<std::string, Entry> _map;
+};
+
+} // namespace chatnow

--- a/common/utils/random_ttl.hpp
+++ b/common/utils/random_ttl.hpp
@@ -1,13 +1,16 @@
 #pragma once
 #include <chrono>
+#include <cmath>
 #include <random>
 
 namespace chatnow {
 inline std::chrono::seconds randomized_ttl(std::chrono::seconds base) {
     long base_sec = base.count();
-    long jitter = base_sec / 5;
+    double jitter_sec = static_cast<double>(base_sec) * 0.20;
     static thread_local std::mt19937 rng(std::random_device{}());
-    std::uniform_int_distribution<long> dist(-jitter, jitter);
-    return std::chrono::seconds(base_sec + dist(rng));
+    std::uniform_real_distribution<double> dist(-jitter_sec, jitter_sec);
+    long adjusted = base_sec + static_cast<long>(std::round(dist(rng)));
+    if (adjusted < 1) adjusted = 1;
+    return std::chrono::seconds(adjusted);
 }
 } // namespace chatnow

--- a/common/utils/random_ttl.hpp
+++ b/common/utils/random_ttl.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <chrono>
+#include <random>
+
+namespace chatnow {
+inline std::chrono::seconds randomized_ttl(std::chrono::seconds base) {
+    long base_sec = base.count();
+    long jitter = base_sec / 5;
+    static thread_local std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<long> dist(-jitter, jitter);
+    return std::chrono::seconds(base_sec + dist(rng));
+}
+} // namespace chatnow

--- a/common/utils/redis_mutex.hpp
+++ b/common/utils/redis_mutex.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+#include "common/dao/data_redis.hpp"
+#include "infra/logger.hpp"
+
+namespace chatnow {
+
+// 基于 "SET key token NX PX ttl_ms" + Lua CAS unlock 的短时互斥锁。
+// 用于 cache warm 互斥、backfill 协调等毫秒-秒级场景。
+class RedisMutex {
+public:
+    RedisMutex(RedisClient::ptr redis, const std::string &key, int ttl_ms = 5000)
+        : _redis(std::move(redis)), _key("im:lock:" + key), _ttl_ms(ttl_ms)
+    {
+        _token = generate_token_();
+    }
+
+    bool try_lock(std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            bool ok = _redis->set(_key, _token, std::chrono::milliseconds(_ttl_ms));
+            if (ok) { _locked = true; return true; }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return false;
+    }
+
+    void unlock() {
+        if (!_locked) return;
+        static const char *kUnlockLua =
+            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
+            "    return redis.call('DEL', KEYS[1]) "
+            "end "
+            "return 0";
+        try {
+            std::vector<std::string> keys = {_key};
+            std::vector<std::string> args = {_token};
+            _redis->eval<long long>(kUnlockLua, keys.begin(), keys.end(),
+                                    args.begin(), args.end());
+        } catch (std::exception &e) {
+            LOG_WARN("RedisMutex.unlock 失败 {}: {}", _key, e.what());
+        }
+        _locked = false;
+    }
+
+private:
+    static std::string generate_token_() {
+        static thread_local std::mt19937_64 rng(std::random_device{}());
+        std::uniform_int_distribution<unsigned long long> dist;
+        return std::to_string(dist(rng));
+    }
+
+    RedisClient::ptr _redis;
+    std::string _key;
+    std::string _token;
+    int _ttl_ms;
+    bool _locked = false;
+};
+
+} // namespace chatnow

--- a/common/utils/redis_mutex.hpp
+++ b/common/utils/redis_mutex.hpp
@@ -24,7 +24,8 @@ public:
     bool try_lock(std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
         auto deadline = std::chrono::steady_clock::now() + timeout;
         while (std::chrono::steady_clock::now() < deadline) {
-            bool ok = _redis->set(_key, _token, std::chrono::milliseconds(_ttl_ms));
+            bool ok = _redis->set(_key, _token, std::chrono::milliseconds(_ttl_ms),
+                                  sw::redis::UpdateType::NOT_EXIST);
             if (ok) { _locked = true; return true; }
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
         }

--- a/common/utils/worker_id.hpp
+++ b/common/utils/worker_id.hpp
@@ -29,7 +29,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include <sw/redis++/redis++.h>
+#include "dao/data_redis.hpp"
 #include "infra/logger.hpp"
 
 namespace chatnow
@@ -44,7 +44,7 @@ public:
     static constexpr int kLeaseSec = 300;
     static constexpr int kRenewSec = 60;
 
-    WorkerIdAllocator(const std::shared_ptr<sw::redis::Redis> &c,
+    WorkerIdAllocator(const RedisClient::ptr &c,
                       const std::string &service_name,
                       const std::string &owner)
         : _c(c), _service(service_name), _owner(owner),
@@ -155,7 +155,7 @@ private:
         });
     }
 
-    std::shared_ptr<sw::redis::Redis> _c;
+    RedisClient::ptr _c;
     std::string _service;
     std::string _owner;
     std::atomic<bool> _running;

--- a/conf/conversation_server.conf
+++ b/conf/conversation_server.conf
@@ -15,6 +15,7 @@
 -redis_host=10.0.4.10
 -redis_port=6379
 -redis_db=0
+-redis_seeds=
 -redis_keep_alive=true
 -redis_pool_size=4
 -mysql_host=10.0.4.10

--- a/conf/gateway_server.conf
+++ b/conf/gateway_server.conf
@@ -17,5 +17,6 @@
 -redis_host=10.0.4.10
 -redis_port=6379
 -redis_db=0
+-redis_seeds=
 -redis_keep_alive=true
 -auth_config=/im/conf/auth.json

--- a/conf/identity_server.conf
+++ b/conf/identity_server.conf
@@ -20,6 +20,7 @@
 -redis_host=10.0.4.10
 -redis_port=6379
 -redis_db=0
+-redis_seeds=
 -redis_keep_alive=true
 -mail_user=yhaoyang666@163.com
 -mail_paswd=XKk5zvYwWKeB8xNk

--- a/conf/media_server.conf
+++ b/conf/media_server.conf
@@ -9,3 +9,8 @@
 -listen_port=10002
 -rpc_timeout=-1
 -rpc_threads=1
+-redis_host=10.0.4.10
+-redis_port=6379
+-redis_db=0
+-redis_keep_alive=true
+-redis_seeds=

--- a/conf/message_server.conf
+++ b/conf/message_server.conf
@@ -35,5 +35,6 @@
 -redis_host=10.0.4.10
 -redis_port=6379
 -redis_db=0
+-redis_seeds=
 -redis_keep_alive=true
 -redis_pool_size=8

--- a/conf/presence_server.conf
+++ b/conf/presence_server.conf
@@ -15,6 +15,7 @@
 -redis_host=127.0.0.1
 -redis_port=6379
 -redis_db=0
+-redis_seeds=
 -redis_keep_alive=true
 
 # 状态扫描间隔（秒）

--- a/conf/push_server.conf
+++ b/conf/push_server.conf
@@ -13,6 +13,7 @@
 -redis_host=10.0.4.10
 -redis_port=6379
 -redis_db=0
+-redis_seeds=
 -redis_keep_alive=true
 -redis_pool_size=16
 -mq_user=root

--- a/conf/transmite_server.conf
+++ b/conf/transmite_server.conf
@@ -14,6 +14,7 @@
 -redis_host=10.0.4.10
 -redis_port=6379
 -redis_db=0
+-redis_seeds=
 -redis_keep_alive=true
 -redis_pool_size=8
 -mysql_host=10.0.4.10

--- a/conversation/source/conversation_server.cc
+++ b/conversation/source/conversation_server.cc
@@ -20,6 +20,7 @@ DEFINE_string(message_service,  "/service/message_service",  "Message 子服务�
 DEFINE_string(es_host, "http://127.0.0.1:9200/", "ES搜索引擎服务器URL");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis 服务器访问地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32(redis_port, 6379, "Redis 服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis 选择的库");
 DEFINE_bool(redis_keep_alive, true, "Redis 长连接");
@@ -43,6 +44,7 @@ int main(int argc, char *argv[])
 
     chatnow::ConversationServerBuilder csb;
     csb.make_es_object({FLAGS_es_host});
+    csb.set_redis_seeds(FLAGS_redis_seeds);
     csb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db,
                           FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     csb.make_mysql_object(FLAGS_mysql_user, FLAGS_mysql_pswd, FLAGS_mysql_host,

--- a/conversation/source/conversation_server.h
+++ b/conversation/source/conversation_server.h
@@ -834,9 +834,17 @@ public:
     void make_es_object(const std::vector<std::string> host_list) {
         _es_client = ESClientFactory::create(host_list);
     }
+    void set_redis_seeds(const std::string &seeds) { _redis_seeds = seeds; }
+
     void make_redis_object(const std::string &host, uint16_t port, int db,
                            bool keep_alive, int pool_size) {
-        _redis_client  = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
+        if (!_redis_seeds.empty()) {
+            auto cluster = RedisClusterFactory::create(_redis_seeds, pool_size, keep_alive);
+            _redis_client = std::make_shared<RedisClient>(cluster);
+        } else {
+            auto redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
+            _redis_client = std::make_shared<RedisClient>(redis);
+        }
         _members_cache = std::make_shared<Members>(_redis_client);
     }
     void make_mysql_object(const std::string &user, const std::string &password,
@@ -905,7 +913,8 @@ public:
 
 private:
     std::shared_ptr<elasticlient::Client>   _es_client;
-    std::shared_ptr<sw::redis::Redis>       _redis_client;
+    std::string                             _redis_seeds;
+    RedisClient::ptr       _redis_client;
     Members::ptr                            _members_cache;
     std::shared_ptr<odb::core::database>    _mysql_client;
     Discovery::ptr                          _service_discover;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,12 +93,12 @@ services:
     image: redis:7.2.5
     container_name: redis-cluster-init
     depends_on:
-      - redis-cluster-init-node1
-      - redis-cluster-init-node2
-      - redis-cluster-init-node3
-      - redis-cluster-init-node4
-      - redis-cluster-init-node5
-      - redis-cluster-init-node6
+      - redis-node1
+      - redis-node2
+      - redis-node3
+      - redis-node4
+      - redis-node5
+      - redis-node6
     entrypoint: |
       /bin/sh -c "
       echo 'Waiting for all Redis nodes...' &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,16 +29,91 @@ services:
     ports:
       - 3306:3306
     restart: always
-  redis:
-    image: redis:7.0.15
-    container_name: redis-service
+  redis-node1:
+    image: redis:7.2.5
+    container_name: redis-node1
+    command: redis-server --port 6379 --cluster-enabled yes --cluster-config-file /data/nodes.conf --cluster-node-timeout 5000 --appendonly yes --appendfilename appendonly-1.aof
     volumes:
-      #1. 希望容器内的程序能访问宿主机上的文件
-      #2. 希望容器内程序运行所产生的数据文件能落在宿主机上
-      - ./middle/data/redis:/var/lib/redis:rw
+      - ./middle/data/redis/node1:/data:rw
     ports:
-      - 6379:6379
+      - "6379:6379"
     restart: always
+
+  redis-node2:
+    image: redis:7.2.5
+    container_name: redis-node2
+    command: redis-server --port 6380 --cluster-enabled yes --cluster-config-file /data/nodes.conf --cluster-node-timeout 5000 --appendonly yes --appendfilename appendonly-2.aof
+    volumes:
+      - ./middle/data/redis/node2:/data:rw
+    ports:
+      - "6380:6380"
+    restart: always
+
+  redis-node3:
+    image: redis:7.2.5
+    container_name: redis-node3
+    command: redis-server --port 6381 --cluster-enabled yes --cluster-config-file /data/nodes.conf --cluster-node-timeout 5000 --appendonly yes --appendfilename appendonly-3.aof
+    volumes:
+      - ./middle/data/redis/node3:/data:rw
+    ports:
+      - "6381:6381"
+    restart: always
+
+  redis-node4:
+    image: redis:7.2.5
+    container_name: redis-node4
+    command: redis-server --port 6382 --cluster-enabled yes --cluster-config-file /data/nodes.conf --cluster-node-timeout 5000 --appendonly yes --appendfilename appendonly-4.aof
+    volumes:
+      - ./middle/data/redis/node4:/data:rw
+    ports:
+      - "6382:6382"
+    restart: always
+
+  redis-node5:
+    image: redis:7.2.5
+    container_name: redis-node5
+    command: redis-server --port 6383 --cluster-enabled yes --cluster-config-file /data/nodes.conf --cluster-node-timeout 5000 --appendonly yes --appendfilename appendonly-5.aof
+    volumes:
+      - ./middle/data/redis/node5:/data:rw
+    ports:
+      - "6383:6383"
+    restart: always
+
+  redis-node6:
+    image: redis:7.2.5
+    container_name: redis-node6
+    command: redis-server --port 6384 --cluster-enabled yes --cluster-config-file /data/nodes.conf --cluster-node-timeout 5000 --appendonly yes --appendfilename appendonly-6.aof
+    volumes:
+      - ./middle/data/redis/node6:/data:rw
+    ports:
+      - "6384:6384"
+    restart: always
+
+  redis-cluster-init:
+    image: redis:7.2.5
+    container_name: redis-cluster-init
+    depends_on:
+      - redis-cluster-init-node1
+      - redis-cluster-init-node2
+      - redis-cluster-init-node3
+      - redis-cluster-init-node4
+      - redis-cluster-init-node5
+      - redis-cluster-init-node6
+    entrypoint: |
+      /bin/sh -c "
+      echo 'Waiting for all Redis nodes...' &&
+      sleep 10 &&
+      echo 'Creating 3-master 3-slave cluster...' &&
+      echo yes | redis-cli --cluster create \
+        redis-node1:6379 redis-node2:6380 redis-node3:6381 \
+        redis-node4:6382 redis-node5:6383 redis-node6:6384 \
+        --cluster-replicas 1 &&
+      echo 'Verifying cluster...' &&
+      redis-cli --cluster check redis-node1:6379 &&
+      echo 'Cluster ready.' &&
+      tail -f /dev/null
+      "
+    restart: "no"
   elasticsearch:
     image: elasticsearch:7.17.21
     container_name: elasticsearch-service
@@ -81,9 +156,10 @@ services:
     restart: always
     depends_on:
       - etcd
+      - redis-cluster-init
     entrypoint:
       # 与dockerfile的cmd类似---替代dockerfile的cmd
-      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379 -c "/im/bin/media_server -flagfile=/im/conf/media_server.conf"
+      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,6379,6380,6381,6382,6383,6384 -c "/im/bin/media_server -flagfile=/im/conf/media_server.conf -redis_seeds=redis-node1:6379,redis-node2:6380,redis-node3:6381,redis-node4:6382,redis-node5:6383,redis-node6:6384"
   relationship_server:
     build: ./relationship
     container_name: relationship_server-service
@@ -119,10 +195,10 @@ services:
     depends_on:
       - etcd
       - mysql
-      - redis
+      - redis-cluster-init
       - elasticsearch
     entrypoint:
-      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,6379,9200 -c "/im/bin/conversation_server -flagfile=/im/conf/conversation_server.conf"
+      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,6379,6380,6381,6382,6383,6384,9200 -c "/im/bin/conversation_server -flagfile=/im/conf/conversation_server.conf -redis_seeds=redis-node1:6379,redis-node2:6380,redis-node3:6381,redis-node4:6382,redis-node5:6383,redis-node6:6384"
   gateway_server:
     build: ./gateway
     container_name: gateway_server-service
@@ -139,10 +215,10 @@ services:
     restart: always
     depends_on:
       - etcd
-      - redis
+      - redis-cluster-init
     entrypoint:
       # 与dockerfile的cmd类似---替代dockerfile的cmd
-      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,6379 -c "/im/bin/gateway_server -flagfile=/im/conf/gateway_server.conf"
+      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,6379,6380,6381,6382,6383,6384 -c "/im/bin/gateway_server -flagfile=/im/conf/gateway_server.conf -redis_seeds=redis-node1:6379,redis-node2:6380,redis-node3:6381,redis-node4:6382,redis-node5:6383,redis-node6:6384"
   push_server:
     build: ./push
     container_name: push_server-service
@@ -157,10 +233,10 @@ services:
     restart: always
     depends_on:
       - etcd
-      - redis
+      - redis-cluster-init
       - rabbitmq
     entrypoint:
-      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,6379,5672 -c "/im/bin/push_server -flagfile=/im/conf/push_server.conf"
+      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,6379,6380,6381,6382,6383,6384,5672 -c "/im/bin/push_server -flagfile=/im/conf/push_server.conf -redis_seeds=redis-node1:6379,redis-node2:6380,redis-node3:6381,redis-node4:6382,redis-node5:6383,redis-node6:6384"
   message_server:
     build: ./message
     container_name: message_server-service
@@ -180,9 +256,10 @@ services:
       - mysql
       - elasticsearch
       - rabbitmq
+      - redis-cluster-init
     entrypoint:
       # 与dockerfile的cmd类似---替代dockerfile的cmd
-      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,9200,5672 -c "/im/bin/message_server -flagfile=/im/conf/message_server.conf"
+      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,6379,6380,6381,6382,6383,6384,9200,5672 -c "/im/bin/message_server -flagfile=/im/conf/message_server.conf -redis_seeds=redis-node1:6379,redis-node2:6380,redis-node3:6381,redis-node4:6382,redis-node5:6383,redis-node6:6384"
   transmite_server:
     build: ./transmite
     container_name: transmite_server-service
@@ -201,9 +278,10 @@ services:
       - etcd
       - mysql
       - rabbitmq
+      - redis-cluster-init
     entrypoint:
       # 与dockerfile的cmd类似---替代dockerfile的cmd
-      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,5672 -c "/im/bin/transmite_server -flagfile=/im/conf/transmite_server.conf"
+      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,6379,6380,6381,6382,6383,6384,5672 -c "/im/bin/transmite_server -flagfile=/im/conf/transmite_server.conf -redis_seeds=redis-node1:6379,redis-node2:6380,redis-node3:6381,redis-node4:6382,redis-node5:6383,redis-node6:6384"
   identity_server:
     build: ./identity
     container_name: identity_server-service
@@ -221,8 +299,8 @@ services:
     depends_on:
       - etcd
       - mysql
-      - redis
+      - redis-cluster-init
       - elasticsearch
     entrypoint:
       # 与dockerfile的cmd类似---替代dockerfile的cmd
-      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,6379,9200 -c "/im/bin/identity_server -flagfile=/im/conf/identity_server.conf"
+      /im/bin/entrypoint.sh -h 10.0.4.10 -p 2379,3306,6379,6380,6381,6382,6383,6384,9200 -c "/im/bin/identity_server -flagfile=/im/conf/identity_server.conf -redis_seeds=redis-node1:6379,redis-node2:6380,redis-node3:6381,redis-node4:6382,redis-node5:6383,redis-node6:6384"

--- a/docs/superpowers/specs/2026-05-18-cache-infrastructure-redesign.md
+++ b/docs/superpowers/specs/2026-05-18-cache-infrastructure-redesign.md
@@ -1,0 +1,708 @@
+# ChatNow 缓存基础设施重构设计
+
+> **日期**: 2026-05-18
+> **基线**: 3.0-dev
+> **范围**: Redis 集群化 / 多级缓存 / 分布式锁分层 / 缓存防护体系
+> **关联**: `2026-05-13-cache-strategy-redesign.md`（数据层改进，本设计的基础设施层补充）
+
+---
+
+## 0. 设计目标
+
+在不考虑老版本和客户端兼容性的前提下，将缓存基础设施从"单机 Redis + 单层缓存"升级到支持大规模 IM 场景的"Redis Cluster + 多级缓存 + 分层锁"架构。
+
+### 0.1 目标规模
+
+- DAU: 50 万+
+- 峰值消息量: 5000+ msg/s
+- 群规模: 最大 2000 人/群
+- 服务实例: 每服务 2-8 实例
+
+### 0.2 当前痛点（来自 review）
+
+| # | 痛点 | 当前 | 目标 |
+|---|------|------|------|
+| 1 | 单 Redis 实例 | 无 HA，挂了全链路停摆 | Redis Cluster 3 主 3 从 |
+| 2 | 无本地缓存 | OnlineRoute 每条消息 200 次 Redis HKEYS | 本地短 TTL 缓存，削减 90%+ Redis 读 |
+| 3 | 分布式锁分散 | Outbox reaper 用 Lua CAS，Snowflake 用 etcd 租约，不一致 | 统一分层：etcd 管选举，Redis 管互斥 |
+| 4 | 无防击穿 | 热点 key 过期 → N 个并发同时穿透 | InflightRegistry（已有设计）+ 本地缓存兜底 |
+| 5 | TTL 雪崩 | 固定 TTL，集中过期 | 随机偏移 TTL（已有设计） |
+| 6 | 缓存穿透 | 不存在的数据反复查 | 空值缓存（sentinel） |
+
+---
+
+## 1. Redis 集群化
+
+### 1.1 拓扑：3 主 3 从 Cluster
+
+```
+                 ┌──────────────────────────────────────┐
+                 │         Redis Cluster (6 nodes)       │
+                 │                                      │
+                 │  Master A (slot 0-5460)   ── Slave A │
+                 │  Master B (slot 5461-10922) ── Slave B│
+                 │  Master C (slot 10923-16383)── Slave C│
+                 │                                      │
+                 │  自动 failover: Sentinel 内置于       │
+                 │  Redis Cluster (cluster-replica-no)   │
+                 └──────────────────────────────────────┘
+```
+
+- **选型**: Redis 7.x Cluster 原生模式（内置 gossip + 自动 failover）
+- **为什么不用 Codis/Proxy 方案**: 代理层多一跳延迟 + 单点瓶颈；原生 Cluster 的 smart client 自动重定向，延迟更低
+- **为什么不用 Sentinel 主从**: Sentinel 只能管一个分片，无法横向扩展；Cluster 管 16384 个 slot，吞吐随节点数线性增长
+
+### 1.2 分片策略
+
+**不加 hash tag，自然 CRC16 分布**。
+
+理由：
+- 所有 Redis 操作都是单 key（INCR / SADD / HSET / ZADD / Lua EVAL），无跨 key 原子性需求
+- `SeqGen::next_user_seq_batch` 的 pipeline INCR 由 sw::redis++ `RedisCluster` 自动按 slot 分组转发
+- 不加 hash tag 避免热点——`im:seq:ssid:abc123` 和 `im:members:ssid:abc123` 落在不同节点
+
+### 1.3 客户端改造
+
+当前 `RedisClientFactory` 返回 `sw::redis::Redis`（单机客户端），新增 `RedisClusterFactory`：
+
+```cpp
+// common/dao/data_redis.hpp
+
+class RedisClusterFactory {
+public:
+    static std::shared_ptr<sw::redis::RedisCluster> create(
+        const std::vector<std::string> &seed_nodes,  // {"10.0.4.10:6379", "10.0.4.11:6379", ...}
+        int pool_size = 16,                           // 每节点的连接池
+        bool keep_alive = true)
+    {
+        sw::redis::ConnectionOptions copts;
+        copts.connect_timeout = std::chrono::milliseconds(2000);
+        copts.socket_timeout  = std::chrono::milliseconds(2000);
+        copts.keep_alive = keep_alive;
+
+        sw::redis::ConnectionPoolOptions popts;
+        popts.size = pool_size;
+        popts.wait_timeout = std::chrono::milliseconds(500);
+        popts.connection_lifetime = std::chrono::minutes(30);
+
+        return std::make_shared<sw::redis::RedisCluster>(copts, popts);
+    }
+};
+```
+
+**各服务使用策略**：
+
+| 服务 | 客户端类型 | 原因 |
+|------|-----------|------|
+| Transmite | RedisCluster | SeqGen INCR + Members 读 + RateLimiter，高频 |
+| Message | RedisCluster | SeqGen backfill + PushOutbox + ESOutbox |
+| Push | RedisCluster | OnlineRoute + UnackedPush + Presence，高频 |
+| ChatSession | RedisCluster | Members 写（add/remove）+ LastMessage |
+| Identity | RedisCluster | Session + Codes + Status |
+| Gateway | RedisCluster | Session 校验（仅读） |
+| Media | RedisCluster | 限流 + 上传配额 |
+
+### 1.4 配置变更
+
+所有 `*.conf` 文件从单地址改为种子节点列表：
+
+```
+# 旧
+-redis_host=10.0.4.10
+-redis_port=6379
+
+# 新
+-redis_seeds=10.0.4.10:6379,10.0.4.11:6379,10.0.4.12:6379
+-redis_pool_size=16
+```
+
+---
+
+## 2. 多级缓存架构
+
+### 2.1 分层模型
+
+```
+                         ┌──────────────────────┐
+       get(key)          │   L1: 本地内存缓存    │  ~ns 级延迟
+    ────────────────────▶│   tsl::hopscotch_map  │
+                         │   + mutex + TTL       │
+                         └──────────┬───────────┘
+                                    │ miss
+                                    ▼
+                         ┌──────────────────────┐
+                         │   L2: Redis Cluster   │  ~0.5ms 延迟
+                         │   真相源 (SoT)        │
+                         └──────────┬───────────┘
+                                    │ miss（仅 Members/UserInfo）
+                                    ▼
+                         ┌──────────────────────┐
+                         │   L3: RPC / DB        │  ~5-20ms 延迟
+                         │   ChatSession RPC     │
+                         │   或 MySQL            │
+                         └──────────────────────┘
+```
+
+### 2.2 L1 本地缓存设计
+
+不是所有 key 都需要本地缓存。需要本地缓存的判断标准：
+
+| 数据 | 本地缓存 | TTL | 理由 |
+|------|---------|-----|------|
+| OnlineRoute (用户→设备→实例) | **是** | 1-3s | 每条群消息查 N 次，N=群成员数。1s 过期可削减 99% Redis 读 |
+| Members (群成员列表) | **是** | 5-10s | 活跃群高频访问，成员变更低频。10s 过期 + 变更时主动失效 |
+| UserInfo (用户昵称/头像) | **是** | 30-60s | 用户信息几乎不变，30s 过期可接受 |
+| ChatSession list | **是** | 10-30s | 会话列表高频访问 |
+| SeqGen (序号) | **否** | — | 必须强一致，INCR 走 Redis |
+| RateLimiter (限流) | **否** | — | 必须跨实例共享计数 |
+| UnackedPush (未 ACK) | **否** | — | 必须持久化，实例 crash 后重启仍需要 |
+| PushOutbox / ESOutbox | **否** | — | 必须持久化到 Redis |
+| Session (登录态) | **否** | — | 已由调用方做本地校验（JWT） |
+
+### 2.3 LocalCache 通用组件
+
+```cpp
+// common/utils/local_cache.hpp
+#pragma once
+
+#include <shared_mutex>
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <optional>
+
+namespace chatnow {
+
+template <typename V>
+class LocalCache {
+public:
+    using ptr = std::shared_ptr<LocalCache<V>>;
+
+    struct Entry {
+        V value;
+        std::chrono::steady_clock::time_point expires_at;
+    };
+
+    // size_hint: 预估 key 数量上限
+    explicit LocalCache(size_t size_hint = 4096) {
+        _map.reserve(size_hint);
+    }
+
+    std::optional<V> get(const std::string &key) {
+        std::shared_lock lk(_mu);
+        auto it = _map.find(key);
+        if (it == _map.end()) return std::nullopt;
+        if (std::chrono::steady_clock::now() > it->second.expires_at) {
+            // 过期不移除（lazy），由后续 set 覆盖
+            return std::nullopt;
+        }
+        return it->second.value;
+    }
+
+    void set(const std::string &key, const V &value,
+             std::chrono::seconds ttl) {
+        std::unique_lock lk(_mu);
+        _map[key] = {value, std::chrono::steady_clock::now() + ttl};
+    }
+
+    // CAS: 仅当 key 不存在时设置（防击穿用——第一个 miss 的请求 set，后续直接 get）
+    bool set_if_absent(const std::string &key, const V &value,
+                       std::chrono::seconds ttl) {
+        std::unique_lock lk(_mu);
+        auto it = _map.find(key);
+        if (it != _map.end() &&
+            std::chrono::steady_clock::now() <= it->second.expires_at) {
+            return false;  // 已存在且未过期
+        }
+        _map[key] = {value, std::chrono::steady_clock::now() + ttl};
+        return true;
+    }
+
+    void invalidate(const std::string &key) {
+        std::unique_lock lk(_mu);
+        _map.erase(key);
+    }
+
+    // 后台清理过期条目（可定期调用或在 size 超过阈值时触发）
+    size_t evict_expired() {
+        std::unique_lock lk(_mu);
+        auto now = std::chrono::steady_clock::now();
+        size_t removed = 0;
+        for (auto it = _map.begin(); it != _map.end(); ) {
+            if (now > it->second.expires_at) {
+                it = _map.erase(it);
+                ++removed;
+            } else {
+                ++it;
+            }
+        }
+        return removed;
+    }
+
+    size_t size() const {
+        std::shared_lock lk(_mu);
+        return _map.size();
+    }
+
+private:
+    mutable std::shared_mutex _mu;
+    std::unordered_map<std::string, Entry> _map;
+};
+
+} // namespace chatnow
+```
+
+### 2.4 多级缓存读路径模板
+
+以 OnlineRoute 为例，Push 服务中 `instances(uid)` 的读路径：
+
+```
+OnlineRouteService::instances(uid):
+  ① local = _local_cache.get("route:" + uid)
+     if local → return local
+
+  ② redis = _redis_cluster.hgetall("im:online:" + uid)
+     if redis not empty:
+       _local_cache.set("route:" + uid, redis, TTL=2s)
+       return redis
+
+  ③ return {}  // 用户不在线
+```
+
+以 Members 为例，Transmite 中 `resolve_members(ssid)` 的读路径：
+
+```
+MembersResolver::resolve(ssid):
+  ① local = _local_cache.get("members:" + ssid)
+     if local → return local
+
+  ② redis = _members_cache.list(ssid)
+     if redis not empty:
+       _local_cache.set("members:" + ssid, redis, TTL=8s)
+       return redis
+
+  ③ // 以下走现有 InflightRegistry + RPC 回填逻辑
+```
+
+### 2.5 本地缓存失效策略
+
+| 触发方 | 操作 | 方法 |
+|--------|------|------|
+| ChatSession 加人/踢人 | 失效对应 ssid 的 Members 本地缓存 | **不需要主动失效**——5-10s TTL 自动过期。成员变更频率极低（< 0.01/s/群），10s 窗口可接受 |
+| User 改资料 | 失效对应 uid 的 UserInfo 本地缓存 | 同上——30s TTL 自动过期 |
+| Push 实例上线/下线 | OnlineRoute 由 Redis online key 的 TTL 控制 | 本地缓存 1-3s，Redis TTL 30s，心跳续期 |
+
+**结论：本地缓存完全通过短 TTL 自愈，不需要跨服务失效通知。** 这避免引入 Pub/Sub 或 gRPC 通知的复杂性。
+
+---
+
+## 3. 分布式锁分层方案
+
+### 3.1 分层决策
+
+| 层级 | 技术 | 场景 | 持锁时间 | 一致性要求 |
+|------|------|------|----------|-----------|
+| **Tier 1: 选举锁** | etcd 租约 (Lease) | Outbox reaper 选举、Snowflake worker_id 分配 | 30-60s，持续续约 | 强一致（Raft） |
+| **Tier 2: 短时互斥锁** | Redis Lua CAS | InflightRegistry 分布式版、cache warm 互斥、SeqGen backfill 协调 | 毫秒-秒级 | 最终一致可接受 |
+
+### 3.2 Tier 1: etcd 选举锁
+
+**为什么用 etcd？**
+- 项目已经依赖 etcd 做服务发现（`registry_host=http://10.0.4.10:2379`），零新增组件
+- etcd v3 的 Lease + Transaction 提供强一致 CAS（基于 Raft），不会出现脑裂双主
+- 持锁时间 30-60s 的场景，etcd 的写延迟（~10ms）完全可接受
+
+**统一选举锁组件**：
+
+```cpp
+// common/infra/leader_election.hpp
+#pragma once
+
+#include <etcd/Client.hpp>
+#include <etcd/LeaseKeepAlive.hpp>
+#include <functional>
+#include <atomic>
+
+namespace chatnow {
+
+// etcd 选举锁：自动续约 + 租约丢失回调
+class LeaderElection {
+public:
+    using ptr = std::shared_ptr<LeaderElection>;
+
+    // on_acquired: 成为 leader 时回调
+    // on_lost:     失去 leader 时回调（租约过期 / etcd 不可达）
+    LeaderElection(
+        std::shared_ptr<etcd::Client> etcd,
+        const std::string &election_key,  // e.g. "/chatnow/push_outbox_reaper/leader"
+        const std::string &instance_id,
+        int lease_ttl_sec,
+        std::function<void()> on_acquired,
+        std::function<void()> on_lost);
+
+    // 启动选举循环（blocking 方式在独立线程中运行）
+    void start();
+    void stop();
+
+    bool is_leader() const { return _is_leader.load(); }
+
+private:
+    void campaign_loop_();  // Campaign → keepalive → watch
+    // ...
+};
+
+} // namespace chatnow
+```
+
+**使用场景映射**：
+
+| 场景 | election_key | lease_ttl |
+|------|-------------|-----------|
+| PushOutbox reaper | `/chatnow/reaper/push_outbox` | 30s |
+| ESOutbox reaper | `/chatnow/reaper/es_outbox` | 30s |
+| CrossInstanceOutbox reaper | `/chatnow/reaper/cross_outbox` | 30s |
+| Snowflake worker_id | `/chatnow/snowflake/worker/{id}` | 60s |
+
+### 3.3 Tier 2: Redis 短时互斥锁
+
+用于高频、短时、可容忍偶尔失败的场景：
+
+```cpp
+// common/utils/redis_mutex.hpp
+// 基于 "SET key value NX PX ttl_ms" 的短时互斥锁
+// 非重入、非公平、无自动续约
+
+class RedisMutex {
+public:
+    // ttl_ms: 锁自动过期时间（防止持锁方 crash 后死锁）
+    RedisMutex(std::shared_ptr<sw::redis::RedisCluster> redis,
+               const std::string &key, int ttl_ms = 5000);
+
+    // 尝试获取锁，阻塞直到成功或超时
+    bool try_lock(std::chrono::milliseconds timeout = std::chrono::milliseconds(100));
+
+    // 释放锁（Lua CAS: 仅 owner 一致时 DEL）
+    void unlock();
+
+private:
+    std::string _key;
+    std::string _token;  // 随机 token，保证只有持锁方能释放
+    int _ttl_ms;
+};
+```
+
+**使用场景**：
+
+| 场景 | key 模式 | ttl |
+|------|----------|-----|
+| Members warm 互斥（分布式 singleflight） | `im:lock:warm:members:{ssid}` | 5s |
+| UserInfo warm 互斥 | `im:lock:warm:user:{uid}` | 3s |
+| SeqGen backfill 互斥（多 Message 实例启动竞争） | `im:lock:backfill:seq` | 30s |
+
+### 3.4 为什么不用 Redlock
+
+Redlock 要求 N 个**独立** Redis 实例（不需要是 Cluster 节点），而 ChatNow 的 Redis Cluster 节点之间是 gossip 互联的，不满足 Redlock 的"独立实例"前提。在容器/虚拟化环境中，Redis 进程的时钟跳跃风险也无法消除。
+
+---
+
+## 4. 缓存防护体系
+
+### 4.1 防击穿（Cache Stampede）
+
+**已有设计**：`InflightRegistry`（per-key 进程内互斥 + double-check），见 `2026-05-13-cache-strategy-redesign.md` §3。
+
+**新增增强**：与 L1 本地缓存联动。
+
+```
+resolve_members(ssid):
+  ① L1 hit → return（快速路径，~ns）
+  ② L1 miss → InflightRegistry.acquire(ssid)
+  ③ double-check L1（可能其他线程刚 warm 完）
+  ④ double-check L2 Redis
+  ⑤ 穿透 RPC → warm L2 → warm L1 → release
+```
+
+⚠️ **注意**：InflightRegistry 是进程内的，多实例间仍有并发穿透可能。高频场景（如大群热点）建议叠加 RedisMutex（Tier 2 锁）做跨实例互斥。
+
+### 4.2 防穿透（Cache Penetration）
+
+对**确认不存在**的数据缓存空标记：
+
+```cpp
+// MembersResolver::resolve(ssid) 末尾:
+if (members.empty()) {
+    // 会话不存在或已解散：缓存空标记 60s，避免反复穿透
+    _members_cache.warm_sentinel(ssid, std::chrono::seconds(60));
+    _local_cache.set("members:" + ssid, {}, std::chrono::seconds(60));
+    return {};
+}
+```
+
+```cpp
+// Members 类新增:
+void warm_sentinel(const std::string &ssid, std::chrono::seconds ttl) {
+    try {
+        std::string k = key::kMembers + ssid;
+        _c->sadd(k, "__sentinel__");  // 特殊标记值
+        _c->expire(k, ttl);
+    } catch (...) { ... }
+}
+```
+
+读路径判别：
+```cpp
+auto members = _members_cache.list(ssid);
+if (members.size() == 1 && members[0] == "__sentinel__") {
+    return {};  // 确认不存在的会话
+}
+```
+
+### 4.3 防雪崩（Cache Avalanche）
+
+**已有设计**：`randomized_ttl()`，见 `2026-05-13-cache-strategy-redesign.md` §2。
+
+本设计扩展应用范围：**所有** TTL 操作都走随机偏移（不仅是 Members），包括：
+
+| 缓存 | base TTL | 随机偏移范围 |
+|------|----------|-------------|
+| Members | 30min | 24-36min |
+| UserInfo | 1h | 48-72min |
+| OnlineRoute | 120s | 96-144s |
+| L1 OnlineRoute | 2s | 1.6-2.4s |
+| L1 Members | 8s | 6.4-9.6s |
+| L1 UserInfo | 45s | 36-54s |
+
+---
+
+## 5. 服务层改动
+
+### 5.1 Transmite
+
+```
+TransmiteServerBuilder 新增:
+  - _redis_cluster    → 替代 _redis
+  - _local_cache_members → LocalCache<vector<string>>
+  - _local_cache_user    → LocalCache<UserInfo>
+
+TransmiteServiceImpl 新增:
+  - resolve_members_with_cache()   → L1 → L2 → Inflight → RPC
+  - resolve_user_with_cache()      → L1 → L2 → UserInfoCache → RPC
+```
+
+### 5.2 Push
+
+```
+PushServerBuilder 新增:
+  - _redis_cluster         → 替代 _redis
+  - _local_cache_route     → LocalCache<RouteEntry>
+
+PushServiceImpl 新增:
+  - online_route_with_cache()  → L1 → L2 → bind/touch
+  - _on_close → 清理本地路由缓存
+```
+
+### 5.3 Message
+
+```
+MessageServerBuilder 新增:
+  - _redis_cluster → 替代 _redis
+  - _leader_election_reaper → 替代 PushOutbox::try_acquire_reaper_lease (Redis Lua)
+
+消息量小的服务无需 L1 本地缓存（Message 是 DB/ES 消费端，缓存读写频率低）
+```
+
+### 5.4 ChatSession
+
+```
+ChatSessionServerBuilder 新增:
+  - _redis_cluster → 替代 _redis
+
+不需要 L1 本地缓存（ChatSession 是缓存写入方，不是高频读取方）
+```
+
+---
+
+## 6. 在线路由可靠性增强
+
+### 6.1 OnlineRoute TTL 优化
+
+| 参数 | 当前 | 改后 | 理由 |
+|------|------|------|------|
+| OnlineRoute TTL | 120s | **30s** | 减少实例 crash 后的路由残留窗口 |
+| 心跳续期间隔 | 当前心跳周期 | **≤15s** | 保证 TTL 在心跳周期内至少续约一次 |
+| L1 本地路由缓存 TTL | 无 | **1-3s** | 削减 Redis 读，不影响一致性 |
+
+### 6.2 Push 实例关停清理
+
+在 `PushServer::stop()` 中增加：
+
+```cpp
+void PushServer::stop() {
+    _ws_server->stop();
+
+    // 遍历所有连接，清理 OnlineRoute
+    for (const auto &[uid, conn] : _connections) {
+        for (const auto &device_id : conn.devices()) {
+            _online_route->unbind(uid, device_id, _instance_id);
+        }
+        // 同时清理本地和 L1 缓存
+        _local_cache_route->invalidate("route:" + uid);
+    }
+
+    // 释放 etcd reaper 租约
+    _leader_election->stop();
+}
+```
+
+### 6.3 僵死实例扫描（新增）
+
+独立后台线程在 Push 服务中运行，周期性扫描 OnlineRoute 中指向不可达实例的路由：
+
+```cpp
+void PushServer::reap_stale_routes_() {
+    // 每 30s 执行
+    // 1. 从 etcd 获取当前在线的 Push 实例列表
+    // 2. SCAN im:online:* 所有 key
+    // 3. 对于每个 (uid, device_id) → instance_id 映射
+    //    如果 instance_id 不在在线列表中 → HDEL
+    // 4. 可选：转为 LeaderElection 保护的单 reaper 执行
+}
+```
+
+---
+
+## 7. 监控指标
+
+### 7.1 Redis Cluster 指标
+
+| 指标 | 用途 |
+|------|------|
+| `redis_commands_total{cmd, node}` | 每节点命令分布 |
+| `redis_command_duration_ms{cmd, node}` | P50/P99 延迟 |
+| `redis_pool_active_connections{node}` | 连接池饱和度 |
+| `redis_cluster_slots_migrating` | slot 迁移状态 |
+| `redis_memory_used_bytes{node}` | 内存水位 |
+
+### 7.2 本地缓存指标
+
+| 指标 | 用途 |
+|------|------|
+| `local_cache_hit_ratio{cache_name}` | 命中率 (target > 90%) |
+| `local_cache_size{cache_name}` | 条目数 |
+| `local_cache_evictions_total{cache_name}` | 淘汰次数 |
+
+### 7.3 业务级告警
+
+| 告警 | 条件 | 级别 |
+|------|------|------|
+| Redis Cluster 节点 down | `redis_up{node} == 0` > 1min | CRITICAL |
+| 本地缓存命中率骤降 | `rate(local_cache_miss[5m])` 突增 3x | WARNING |
+| Reaper 选举频繁切换 | `leader_election_changes_total` > 2 / 10min | WARNING |
+| Redis 连接池耗尽 | `redis_pool_active >= pool_size` | CRITICAL |
+
+---
+
+## 8. 改动清单
+
+| 文件 | 改动 | 行数（估） |
+|------|------|-----------|
+| `common/dao/data_redis.hpp` | 新增 `RedisClusterFactory`；`Members` 新增 `warm_sentinel`、`touch_ttl` | +50 |
+| `common/utils/local_cache.hpp` | **新增** 通用 L1 本地缓存模板 | +80 |
+| `common/utils/redis_mutex.hpp` | **新增** Redis 短时互斥锁 | +55 |
+| `common/infra/leader_election.hpp` | **新增** etcd 选举锁封装 | +80 |
+| `transmite/source/transmite_server.h` | 集成 L1 Members/UserInfo 缓存 + RedisCluster | +50 |
+| `push/source/push_server.h` | 集成 L1 OnlineRoute 缓存 + RedisCluster + 关停清理 + stale reaper | +70 |
+| `message/source/message_server.h` | RedisCluster + etcd reaper 选举替换 Lua CAS | +40 |
+| `message/source/message_server.h` | `backfill_seq_from_db_` 增加 RedisMutex 跨实例互斥 | +15 |
+| `chatsession/source/chatsession_server.h` | RedisCluster + Members 增量写（add/remove） | +25 |
+| `identity/source/identity_server.h` | RedisCluster | +10 |
+| `gateway/source/gateway_server.h` | RedisCluster | +8 |
+| `media/source/media_server.h` | RedisCluster | +8 |
+| `conf/*.conf` (8个) | `redis_host/port` → `redis_seeds` | +16 |
+| `docker-compose.yml` | Redis Cluster 6 节点容器编排 | +30 |
+| **总计** | | **~537 行** |
+
+---
+
+## 9. 上线顺序
+
+按依赖关系分阶段：
+
+### 阶段 1：基础设施（无业务变更，独立验证）
+
+1. Redis Cluster 部署（docker-compose 编排 6 节点）
+2. `RedisClusterFactory` 实现
+3. 所有服务配置切换到 `redis_seeds`
+4. **验证**：Redis Cluster 健康检查、failover 演练、slot 分布均匀
+
+### 阶段 2：分布式锁统一（依赖阶段 1）
+
+5. `LeaderElection` 封装
+6. PushOutbox / ESOutbox / CrossInstanceOutbox reaper 从 Lua CAS 迁移到 etcd 选举
+7. Snowflake worker_id 分配统一走 etcd LeaderElection
+8. `RedisMutex` 实现（短时互斥）
+9. SeqGen backfill 增加 RedisMutex 跨实例互斥
+10. **验证**：reaper 无脑裂、worker_id 无撞号
+
+### 阶段 3：L1 本地缓存（依赖阶段 1）
+
+11. `LocalCache<T>` 实现
+12. Push 接入 OnlineRoute L1 缓存
+13. Transmite 接入 Members / UserInfo L1 缓存
+14. 关停清理 + stale route reaper
+15. OnlineRoute TTL 调优（120s → 30s）
+16. **验证**：命中率 > 90%、TTL 过期正确、关停清理完整
+
+### 阶段 4：防护体系（依赖阶段 3）
+
+17. 空值缓存 sentinel（防穿透）
+18. 全量 TTL 随机偏移（防雪崩）
+19. **验证**：穿透场景不击穿后端、全服务重启后 TTL 分布均匀
+
+### 阶段 5：监控接入
+
+20. Redis Cluster exporter + Prometheus
+21. 本地缓存 hit/miss/eviction bvar
+22. 告警规则配置
+
+---
+
+## 10. 测试要点
+
+### Redis Cluster
+- [ ] 单节点宕机：自动 failover，无数据丢失，无消息丢失
+- [ ] 全集群重启：SeqGen backfill 正确回填，无 seq 撞号
+- [ ] 多实例并发 INCR 同一 key：seq 严格单调递增
+- [ ] Pipeline INCR 跨 slot：sw::redis++ 自动拆分转发
+
+### 多级缓存
+- [ ] L1 hit → 不访问 Redis（验证通过日志/计数器）
+- [ ] L1 miss → L2 hit → 回填 L1 → 下次 L1 hit
+- [ ] L1 TTL 过期 → L2 读到新数据 → L1 更新
+- [ ] ChatSession 加人后 10s 内 L1 自然过期，新成员出现在 members 列表中
+
+### 分布式锁
+- [ ] etcd reaper 选举：主 crash 后 backup 在 lease_ttl 内接管
+- [ ] 无脑裂：一个 etcd lease 同时只有一个 holder
+- [ ] RedisMutex crash 安全：持锁方 crash 后 TTL 过期自动释放
+
+### 在线路由
+- [ ] Push 实例 crash → 30s 内路由清理（TTL 过期）
+- [ ] Push 优雅关停 → 主动 unbind + L1 清理，< 1s 生效
+- [ ] 用户切换 Push 实例 → 新路由即时生效，旧路由 TTL 自清
+
+---
+
+## 11. 总结
+
+本设计与 `2026-05-13-cache-strategy-redesign.md`（数据层改进）形成互补：
+
+| 层面 | 2026-05-13 spec（数据层） | 本 spec（基础设施层） |
+|------|--------------------------|---------------------|
+| Redis 拓扑 | 单实例（未涉及） | Redis Cluster 3 主 3 从 |
+| 缓存层级 | 仅 Redis | L1 本地 + L2 Redis Cluster |
+| 锁机制 | Lua CAS | etcd 选举 + Redis 短时互斥分层 |
+| 防护 | 随机 TTL + InflightRegistry | + 空值 sentinel + 全量随机 TTL |
+| 在线路由 | TTL 120s | TTL 30s + 关停清理 + stale reaper |
+
+两个 spec 共同覆盖了 review 报告中识别的所有硬伤和设计缺陷。

--- a/gateway/source/gateway_server.cc
+++ b/gateway/source/gateway_server.cc
@@ -22,6 +22,7 @@ DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 
 DEFINE_int32(redis_port, 6379, "Redis服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis默认库号");
 DEFINE_bool(redis_keep_alive, true, "Redis长连接保活");
+DEFINE_int32(redis_pool_size, 16, "Redis 连接池大小");
 
 DEFINE_string(auth_config, "/im/conf/auth.json", "JWT 鉴权配置文件路径(JSON)");
 
@@ -32,7 +33,7 @@ int main(int argc, char *argv[])
 
     chatnow::GatewayServerBuilder gsb;
     gsb.set_redis_seeds(FLAGS_redis_seeds);
-    gsb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive);
+    gsb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     gsb.make_jwt_object(FLAGS_auth_config);
     gsb.make_discovery_object(FLAGS_registry_host, FLAGS_base_service,
                               FLAGS_identity_service, FLAGS_relationship_service,

--- a/gateway/source/gateway_server.cc
+++ b/gateway/source/gateway_server.cc
@@ -18,6 +18,7 @@ DEFINE_string(presence_service, "/service/presence_service", "Presence 子服务
 DEFINE_string(push_service, "/service/push_service", "Push 子服务名称");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis服务器访问地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32(redis_port, 6379, "Redis服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis默认库号");
 DEFINE_bool(redis_keep_alive, true, "Redis长连接保活");
@@ -30,6 +31,7 @@ int main(int argc, char *argv[])
     chatnow::init_logger(FLAGS_run_mode, FLAGS_log_file, FLAGS_log_level);
 
     chatnow::GatewayServerBuilder gsb;
+    gsb.set_redis_seeds(FLAGS_redis_seeds);
     gsb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive);
     gsb.make_jwt_object(FLAGS_auth_config);
     gsb.make_discovery_object(FLAGS_registry_host, FLAGS_base_service,

--- a/gateway/source/gateway_server.h
+++ b/gateway/source/gateway_server.h
@@ -454,6 +454,8 @@ inline void GatewayServer::push_notify(const std::string& target_uid,
 
 class GatewayServerBuilder {
 public:
+    void set_redis_seeds(const std::string& seeds) { _redis_seeds = seeds; }
+
     void make_redis_object(const std::string& host, int port, int db, bool keep_alive) {
         _redis_host = host; _redis_port = port; _redis_db = db; _redis_keep_alive = keep_alive;
     }
@@ -474,8 +476,15 @@ public:
     void make_server_object(int http_port) { _http_port = http_port; }
 
     GatewayServer::ptr build() {
-        auto redis = std::make_shared<sw::redis::Redis>(
-            fmt::format("tcp://{}:{}/{}", _redis_host, _redis_port, _redis_db));
+        chatnow::RedisClient::ptr redis;
+        if (!_redis_seeds.empty()) {
+            auto cluster = chatnow::RedisClusterFactory::create(_redis_seeds);
+            redis = std::make_shared<chatnow::RedisClient>(cluster);
+        } else {
+            auto r = std::make_shared<sw::redis::Redis>(
+                fmt::format("tcp://{}:{}/{}", _redis_host, _redis_port, _redis_db));
+            redis = std::make_shared<chatnow::RedisClient>(r);
+        }
         auto jwt_codec = std::make_shared<::chatnow::auth::JwtCodec>(_jwt_config);
         auto jwt_store = std::make_shared<::chatnow::auth::JwtStore>(redis);
 
@@ -502,6 +511,7 @@ public:
     }
 
 private:
+    std::string _redis_seeds;
     std::string _redis_host; int _redis_port = 6379, _redis_db = 0; bool _redis_keep_alive = true;
     ::chatnow::auth::JwtConfig _jwt_config;
     std::string _reg_host, _base;

--- a/gateway/source/gateway_server.h
+++ b/gateway/source/gateway_server.h
@@ -456,8 +456,8 @@ class GatewayServerBuilder {
 public:
     void set_redis_seeds(const std::string& seeds) { _redis_seeds = seeds; }
 
-    void make_redis_object(const std::string& host, int port, int db, bool keep_alive) {
-        _redis_host = host; _redis_port = port; _redis_db = db; _redis_keep_alive = keep_alive;
+    void make_redis_object(const std::string& host, int port, int db, bool keep_alive, int pool_size = 16) {
+        _redis_host = host; _redis_port = port; _redis_db = db; _redis_keep_alive = keep_alive; _redis_pool_size = pool_size;
     }
     void make_jwt_object(const std::string& auth_config_path) {
         _jwt_config = ::chatnow::auth::load_jwt_config_from_file(auth_config_path);
@@ -481,8 +481,8 @@ public:
             auto cluster = chatnow::RedisClusterFactory::create(_redis_seeds);
             redis = std::make_shared<chatnow::RedisClient>(cluster);
         } else {
-            auto r = std::make_shared<sw::redis::Redis>(
-                fmt::format("tcp://{}:{}/{}", _redis_host, _redis_port, _redis_db));
+            auto r = RedisClientFactory::create(_redis_host, _redis_port, _redis_db,
+                                                _redis_keep_alive, _redis_pool_size);
             redis = std::make_shared<chatnow::RedisClient>(r);
         }
         auto jwt_codec = std::make_shared<::chatnow::auth::JwtCodec>(_jwt_config);
@@ -512,7 +512,7 @@ public:
 
 private:
     std::string _redis_seeds;
-    std::string _redis_host; int _redis_port = 6379, _redis_db = 0; bool _redis_keep_alive = true;
+    std::string _redis_host; int _redis_port = 6379, _redis_db = 0; bool _redis_keep_alive = true; int _redis_pool_size = 16;
     ::chatnow::auth::JwtConfig _jwt_config;
     std::string _reg_host, _base;
     std::string _identity_svc, _relationship_svc, _conversation_svc;

--- a/identity/source/identity_server.cc
+++ b/identity/source/identity_server.cc
@@ -30,6 +30,7 @@ DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 
 DEFINE_int32(redis_port, 6379, "Redis服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis默认库号");
 DEFINE_bool(redis_keep_alive, true, "Redis长连接保活");
+DEFINE_int32(redis_pool_size, 16, "Redis 连接池大小");
 
 DEFINE_string(mail_user, "yhaoyang666@163.com", "邮箱验证平台的用户名");
 DEFINE_string(mail_paswd, "XKk5zvYwWKeB8xNk", "邮箱验证平台的密码");
@@ -47,7 +48,7 @@ int main(int argc, char *argv[])
     isb.make_es_object({FLAGS_es_host});
     isb.make_mysql_object(FLAGS_mysql_user, FLAGS_mysql_pswd, FLAGS_mysql_host, FLAGS_mysql_db, FLAGS_mysql_cset, FLAGS_mysql_port, FLAGS_mysql_pool_count);
     isb.set_redis_seeds(FLAGS_redis_seeds);
-    isb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive);
+    isb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     isb.make_jwt_object(FLAGS_auth_config);
     isb.make_mail_object(FLAGS_mail_user, FLAGS_mail_paswd, FLAGS_mail_host, FLAGS_mail_from);
     isb.make_media_config(FLAGS_media_public_url_prefix);

--- a/identity/source/identity_server.cc
+++ b/identity/source/identity_server.cc
@@ -26,6 +26,7 @@ DEFINE_int32(mysql_port, 0, "MySQL服务器访问端口");
 DEFINE_int32(mysql_pool_count, 4, "MySQL连接池最大连接数量");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis服务器访问地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32(redis_port, 6379, "Redis服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis默认库号");
 DEFINE_bool(redis_keep_alive, true, "Redis长连接保活");
@@ -45,6 +46,7 @@ int main(int argc, char *argv[])
     chatnow::IdentityServerBuilder isb;
     isb.make_es_object({FLAGS_es_host});
     isb.make_mysql_object(FLAGS_mysql_user, FLAGS_mysql_pswd, FLAGS_mysql_host, FLAGS_mysql_db, FLAGS_mysql_cset, FLAGS_mysql_port, FLAGS_mysql_pool_count);
+    isb.set_redis_seeds(FLAGS_redis_seeds);
     isb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive);
     isb.make_jwt_object(FLAGS_auth_config);
     isb.make_mail_object(FLAGS_mail_user, FLAGS_mail_paswd, FLAGS_mail_host, FLAGS_mail_from);

--- a/identity/source/identity_server.h
+++ b/identity/source/identity_server.h
@@ -35,7 +35,7 @@ class IdentityServiceImpl : public ::chatnow::identity::IdentityService
 public:
     IdentityServiceImpl(const std::shared_ptr<odb::core::database> &mysql_client,
                         const std::shared_ptr<elasticlient::Client> &es_client,
-                        const std::shared_ptr<sw::redis::Redis> &redis_client,
+                        const RedisClient::ptr &redis_client,
                         const std::shared_ptr<MailClient> &mail_client,
                         const std::shared_ptr<auth::JwtCodec> &jwt_codec,
                         const std::shared_ptr<auth::JwtStore> &jwt_store,
@@ -526,7 +526,7 @@ public:
             const Registry::ptr &reg_client,
             const std::shared_ptr<elasticlient::Client> &es_client,
             const std::shared_ptr<odb::core::database> &mysql_client,
-            const std::shared_ptr<sw::redis::Redis> &redis_client,
+            const RedisClient::ptr &redis_client,
             const std::shared_ptr<brpc::Server> &server)
         : _service_discover(service_discover),
         _reg_client(reg_client),
@@ -545,7 +545,7 @@ private:
     std::shared_ptr<brpc::Server> _rpc_server;
     std::shared_ptr<elasticlient::Client> _es_client;
     std::shared_ptr<odb::core::database> _mysql_client;
-    std::shared_ptr<sw::redis::Redis> _redis_client;
+    RedisClient::ptr _redis_client;
 };
 
 /* 建造者模式: 将对象真正的构造过程封装，便于后期扩展和调整 */
@@ -565,13 +565,21 @@ public:
     {
         _mysql_client = ODBFactory::create(user, password, host, db, cset, port, conn_pool_count);
     }
-    /* brief: 构造redis客户端对象 */
+    void set_redis_seeds(const std::string &seeds) { _redis_seeds = seeds; }
+
+    /* brief: 构造redis客户端对象（双模：单机 / Cluster） */
     void make_redis_object(const std::string &host,
                         uint16_t port,
                         int db,
                         bool keep_alive)
     {
-        _redis_client = RedisClientFactory::create(host, port, db, keep_alive);
+        if (!_redis_seeds.empty()) {
+            auto cluster = RedisClusterFactory::create(_redis_seeds);
+            _redis_client = std::make_shared<RedisClient>(cluster);
+        } else {
+            auto redis = RedisClientFactory::create(host, port, db, keep_alive);
+            _redis_client = std::make_shared<RedisClient>(redis);
+        }
     }
     /* brief: 加载 JWT 配置并构造 codec / store（必须在 make_redis_object 之后） */
     void make_jwt_object(const std::string &auth_config_path) {
@@ -687,7 +695,8 @@ private:
 
     std::shared_ptr<elasticlient::Client> _es_client;
     std::shared_ptr<odb::core::database> _mysql_client;
-    std::shared_ptr<sw::redis::Redis> _redis_client;
+    std::string _redis_seeds;
+    RedisClient::ptr _redis_client;
     std::shared_ptr<MailClient> _mail_client;
 
     std::string _media_public_url_prefix;

--- a/identity/source/identity_server.h
+++ b/identity/source/identity_server.h
@@ -571,13 +571,14 @@ public:
     void make_redis_object(const std::string &host,
                         uint16_t port,
                         int db,
-                        bool keep_alive)
+                        bool keep_alive,
+                        int pool_size = 16)
     {
         if (!_redis_seeds.empty()) {
             auto cluster = RedisClusterFactory::create(_redis_seeds);
             _redis_client = std::make_shared<RedisClient>(cluster);
         } else {
-            auto redis = RedisClientFactory::create(host, port, db, keep_alive);
+            auto redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
             _redis_client = std::make_shared<RedisClient>(redis);
         }
     }

--- a/media/source/cleanup_worker.hpp
+++ b/media/source/cleanup_worker.hpp
@@ -23,8 +23,7 @@
 #include <vector>
 
 #include <odb/database.hxx>
-#include <sw/redis++/redis++.h>
-
+#include "dao/data_redis.hpp"
 #include "dao/mysql_media_blob_ref.hpp"
 #include "dao/mysql_media_file.hpp"
 #include "dao/mysql_media_user_quota.hpp"
@@ -47,7 +46,7 @@ public:
 
     CleanupWorker(std::shared_ptr<S3Client>            s3,
                   std::shared_ptr<odb::core::database> mysql,
-                  std::shared_ptr<sw::redis::Redis>    redis,
+                  RedisClient::ptr    redis,
                   std::string                          public_bucket,
                   std::string                          private_bucket)
         : _s3(std::move(s3)),
@@ -156,7 +155,7 @@ private:
     }
 
     std::shared_ptr<S3Client>             _s3;
-    std::shared_ptr<sw::redis::Redis>     _redis;
+    RedisClient::ptr     _redis;
     std::shared_ptr<MediaFileTable>       _files;
     std::shared_ptr<MediaBlobRefTable>    _blobs;
     std::shared_ptr<MediaUserQuotaTable>  _quota;

--- a/media/source/media_main.cc
+++ b/media/source/media_main.cc
@@ -42,6 +42,7 @@ DEFINE_int32 (mysql_port, 0, "MySQL 端口");
 DEFINE_int32 (mysql_pool_count, 4, "MySQL 连接池");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis 地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32 (redis_port, 6379, "Redis 端口");
 DEFINE_int32 (redis_db,   0, "Redis 默认库号");
 DEFINE_bool  (redis_keep_alive, true, "Redis 长连接");
@@ -129,6 +130,7 @@ int main(int argc, char* argv[]) {
         b.make_mysql_object(FLAGS_mysql_user, FLAGS_mysql_pswd, FLAGS_mysql_host,
                             FLAGS_mysql_db, FLAGS_mysql_cset, FLAGS_mysql_port,
                             FLAGS_mysql_pool_count);
+        b.set_redis_seeds(FLAGS_redis_seeds);
         b.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db,
                             FLAGS_redis_keep_alive);
         b.make_s3_object(conf.s3_endpoint, conf.s3_region,

--- a/media/source/media_server.h
+++ b/media/source/media_server.h
@@ -59,7 +59,7 @@ public:
     MediaServiceImpl(std::shared_ptr<S3Client> s3,
                      std::shared_ptr<MimeWhitelist> mime,
                      std::shared_ptr<odb::core::database> mysql,
-                     std::shared_ptr<sw::redis::Redis> /*redis*/,
+                     RedisClient::ptr /*redis*/,
                      const MediaServiceConfig& cfg)
     {
         auto files  = std::make_shared<MediaFileTable>(mysql);
@@ -248,7 +248,7 @@ public:
 
     MediaServer(Registry::ptr reg,
                 std::shared_ptr<odb::core::database> mysql,
-                std::shared_ptr<sw::redis::Redis> redis,
+                RedisClient::ptr redis,
                 std::shared_ptr<S3Client> s3,
                 std::shared_ptr<brpc::Server> server,
                 std::unique_ptr<CleanupWorker> worker)
@@ -269,7 +269,7 @@ public:
 private:
     Registry::ptr                          _reg;
     std::shared_ptr<odb::core::database>   _mysql;
-    std::shared_ptr<sw::redis::Redis>      _redis;
+    RedisClient::ptr      _redis;
     std::shared_ptr<S3Client>              _s3;
     std::shared_ptr<brpc::Server>          _rpc_server;
     std::unique_ptr<CleanupWorker>         _worker;
@@ -283,8 +283,16 @@ public:
         _mysql = ODBFactory::create(user, password, host, db, cset, port, pool_count);
     }
 
+    void set_redis_seeds(const std::string& seeds) { _redis_seeds = seeds; }
+
     void make_redis_object(const std::string& host, uint16_t port, int db, bool keep_alive) {
-        _redis = RedisClientFactory::create(host, port, db, keep_alive);
+        if (!_redis_seeds.empty()) {
+            auto cluster = RedisClusterFactory::create(_redis_seeds);
+            _redis = std::make_shared<RedisClient>(cluster);
+        } else {
+            auto redis = RedisClientFactory::create(host, port, db, keep_alive);
+            _redis = std::make_shared<RedisClient>(redis);
+        }
     }
 
     void make_s3_object(const std::string& endpoint, const std::string& region,
@@ -345,7 +353,8 @@ public:
 
 private:
     std::shared_ptr<odb::core::database> _mysql;
-    std::shared_ptr<sw::redis::Redis>    _redis;
+    std::string                _redis_seeds;
+    RedisClient::ptr    _redis;
     std::shared_ptr<S3Client>            _s3;
     std::shared_ptr<MimeWhitelist>       _mime;
     Registry::ptr                        _reg;

--- a/message/source/message_server.cc
+++ b/message/source/message_server.cc
@@ -44,6 +44,7 @@ DEFINE_string(mq_es_binding_key, "msg_queue_es_index", "ES 索引事件绑定键
 DEFINE_string(es_host, "http://127.0.0.1:9200/", "ES搜索引擎服务器URL");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis 服务器访问地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32(redis_port, 6379, "Redis 服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis 选择的库");
 DEFINE_bool(redis_keep_alive, true, "Redis 长连接");
@@ -56,6 +57,7 @@ int main(int argc, char *argv[])
     chatnow::init_logger(FLAGS_run_mode, FLAGS_log_file, FLAGS_log_level);
 
     chatnow::message::MessageServerBuilder msb;
+    msb.set_redis_seeds(FLAGS_redis_seeds);
     msb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db,
                           FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     msb.set_reaper_owner(FLAGS_access_host + ":" + std::to_string(::getpid()));

--- a/message/source/message_server.cc
+++ b/message/source/message_server.cc
@@ -78,6 +78,8 @@ int main(int argc, char *argv[])
                           FLAGS_mysql_pool_count);
     msb.make_discovery_object(FLAGS_registry_host, FLAGS_base_service,
                               FLAGS_identity_service, FLAGS_media_service);
+    msb.set_etcd_client(std::make_shared<etcd::Client>(FLAGS_registry_host));
+    msb.make_reaper_elections();
     msb.make_rpc_object(static_cast<uint16_t>(FLAGS_listen_port),
                         static_cast<uint32_t>(FLAGS_rpc_timeout),
                         static_cast<uint8_t>(FLAGS_rpc_threads));

--- a/message/source/message_server.h
+++ b/message/source/message_server.h
@@ -27,6 +27,7 @@
 #include "log/log_context.hpp"
 #include "infra/logger.hpp"
 #include "infra/etcd.hpp"
+#include "infra/leader_election.hpp"
 #include "mq/channel.hpp"
 #include "dao/mysql_message.hpp"
 #include "dao/mysql_user_timeline.hpp"
@@ -861,11 +862,30 @@ public:
     MessageServer(const std::shared_ptr<brpc::Server> &server,
                   MessageServiceImpl *impl,
                   const Registry::ptr &registry,
-                  const MQClient::ptr &mq_client)
+                  const MQClient::ptr &mq_client,
+                  LeaderElection::ptr push_reaper_election = nullptr,
+                  LeaderElection::ptr es_reaper_election = nullptr,
+                  std::thread *push_reaper_thread = nullptr,
+                  std::thread *es_reaper_thread = nullptr,
+                  std::atomic<bool> *push_reaper_running = nullptr,
+                  std::atomic<bool> *es_reaper_running = nullptr)
         : _rpc_server(server), _service_impl(impl),
-          _registry(registry), _mq_client(mq_client) {}
+          _registry(registry), _mq_client(mq_client),
+          _push_reaper_election(std::move(push_reaper_election)),
+          _es_reaper_election(std::move(es_reaper_election)),
+          _push_reaper_thread(push_reaper_thread),
+          _es_reaper_thread(es_reaper_thread),
+          _push_reaper_running(push_reaper_running),
+          _es_reaper_running(es_reaper_running) {}
 
     ~MessageServer() {
+        // 先停 reaper 线程，再停选举，最后停 RPC
+        if (_push_reaper_running) *_push_reaper_running = false;
+        if (_es_reaper_running) *_es_reaper_running = false;
+        if (_push_reaper_thread && _push_reaper_thread->joinable()) _push_reaper_thread->join();
+        if (_es_reaper_thread && _es_reaper_thread->joinable()) _es_reaper_thread->join();
+        if (_push_reaper_election) _push_reaper_election->stop();
+        if (_es_reaper_election) _es_reaper_election->stop();
         if (_rpc_server) { _rpc_server->Stop(0); _rpc_server->Join(); }
         _mq_client.reset();
     }
@@ -877,6 +897,12 @@ private:
     MessageServiceImpl *_service_impl {nullptr};
     Registry::ptr _registry;
     MQClient::ptr _mq_client;
+    LeaderElection::ptr _push_reaper_election;
+    LeaderElection::ptr _es_reaper_election;
+    std::thread *_push_reaper_thread{nullptr};
+    std::thread *_es_reaper_thread{nullptr};
+    std::atomic<bool> *_push_reaper_running{nullptr};
+    std::atomic<bool> *_es_reaper_running{nullptr};
 };
 
 class MessageServerBuilder {
@@ -1015,6 +1041,66 @@ public:
             _mq_client, _es_index_settings, dummy_cb);
     }
     void set_reaper_owner(const std::string &owner) { _reaper_owner = owner; }
+    void set_etcd_client(std::shared_ptr<etcd::Client> etcd) { _etcd_client = etcd; }
+
+    void make_reaper_elections() {
+        if (!_etcd_client) {
+            LOG_WARN("etcd 未初始化，跳过 reaper 选举");
+            return;
+        }
+        _push_reaper_election = std::make_shared<LeaderElection>(
+            _etcd_client, "/chatnow/reaper/push_outbox", _reaper_owner, 30,
+            []() { LOG_INFO("PushOutbox reaper 成为 leader"); },
+            []() { LOG_INFO("PushOutbox reaper 失去 leader"); });
+        _es_reaper_election = std::make_shared<LeaderElection>(
+            _etcd_client, "/chatnow/reaper/es_outbox", _reaper_owner, 30,
+            []() { LOG_INFO("ESOutbox reaper 成为 leader"); },
+            []() { LOG_INFO("ESOutbox reaper 失去 leader"); });
+    }
+
+    void start_push_outbox_reaper() {
+        _push_reaper_running = true;
+        _push_reaper_thread = std::thread([this]() {
+            while (_push_reaper_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                if (!_push_reaper_election || !_push_reaper_election->is_leader())
+                    continue;
+                try {
+                    auto items = _push_outbox->peek(50);
+                    for (const auto &item : items) {
+                        _push_publisher->publish_confirm(item, {},
+                            [outbox = _push_outbox, item](PublishStatus st, const std::string &) {
+                                if (st == PublishStatus::Acked && outbox) outbox->remove(item);
+                            });
+                    }
+                } catch (std::exception &e) {
+                    LOG_WARN("PushOutbox reaper 异常: {}", e.what());
+                }
+            }
+        });
+    }
+
+    void start_es_outbox_reaper() {
+        _es_reaper_running = true;
+        _es_reaper_thread = std::thread([this]() {
+            while (_es_reaper_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                if (!_es_reaper_election || !_es_reaper_election->is_leader())
+                    continue;
+                try {
+                    auto items = _es_outbox->peek(50);
+                    for (const auto &item : items) {
+                        _es_publisher->publish_confirm(item, {},
+                            [outbox = _es_outbox, item](PublishStatus st, const std::string &) {
+                                if (st == PublishStatus::Acked && outbox) outbox->remove(item);
+                            });
+                    }
+                } catch (std::exception &e) {
+                    LOG_WARN("ESOutbox reaper 异常: {}", e.what());
+                }
+            }
+        });
+    }
 
     void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads) {
         _rpc_server = std::make_shared<brpc::Server>();
@@ -1063,11 +1149,19 @@ public:
         _subscriber_es->consume(std::move(callback_es));
 
         LOG_INFO("MQ 订阅完成，消息服务启动！");
+
+        if (_push_reaper_election) _push_reaper_election->start();
+        if (_es_reaper_election) _es_reaper_election->start();
+        start_push_outbox_reaper();
+        start_es_outbox_reaper();
     }
 
     MessageServer::ptr build() {
         return std::make_shared<MessageServer>(
-            _rpc_server, _service_impl, _registry, _mq_client);
+            _rpc_server, _service_impl, _registry, _mq_client,
+            _push_reaper_election, _es_reaper_election,
+            &_push_reaper_thread, &_es_reaper_thread,
+            &_push_reaper_running, &_es_reaper_running);
     }
 
 private:
@@ -1127,6 +1221,13 @@ private:
     std::string _identity_service_name;
     std::string _media_service_name;
     std::string _reaper_owner;
+    std::shared_ptr<etcd::Client> _etcd_client;
+    LeaderElection::ptr _push_reaper_election;
+    LeaderElection::ptr _es_reaper_election;
+    std::thread _push_reaper_thread;
+    std::thread _es_reaper_thread;
+    std::atomic<bool> _push_reaper_running{false};
+    std::atomic<bool> _es_reaper_running{false};
 
     std::shared_ptr<brpc::Server> _rpc_server;
     MessageServiceImpl *_service_impl {nullptr};

--- a/message/source/message_server.h
+++ b/message/source/message_server.h
@@ -36,6 +36,7 @@
 #include "dao/mysql_message_pin.hpp"
 #include "dao/data_es.hpp"
 #include "dao/data_redis.hpp"
+#include "utils/redis_mutex.hpp"
 #include "mq/rabbitmq.hpp"
 #include "mq/trace_headers.hpp"
 #include "utils/brpc_closure.hpp"
@@ -1170,6 +1171,14 @@ private:
             LOG_WARN("SeqGen / MySQL 未初始化，跳过 seq 回填");
             return;
         }
+
+        // 多实例启动互斥：同一时间只有一个实例执行 backfill
+        RedisMutex backfill_lock(_redis_client, "backfill:seq", 30000);
+        if (!backfill_lock.try_lock(std::chrono::seconds(5))) {
+            LOG_WARN("SeqGen backfill 获取锁超时（其他实例正在执行），跳过");
+            return;
+        }
+
         LOG_INFO("开始从 DB 回填 seq 到 Redis...");
         auto msg_table = std::make_shared<MessageTable>(_odb_db);
         auto timeline_table = std::make_shared<UserTimeLineTable>(_odb_db);

--- a/message/source/message_server.h
+++ b/message/source/message_server.h
@@ -891,12 +891,20 @@ public:
         _mysql_reaction = std::make_shared<MessageReactionTable>(_odb_db);
         _mysql_pin = std::make_shared<MessagePinTable>(_odb_db);
     }
+    void set_redis_seeds(const std::string &seeds) { _redis_seeds = seeds; }
+
     void make_redis_object(const std::string &host, uint16_t port, int db,
                            bool keep_alive, int pool_size) {
-        _redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
-        _seq_gen = std::make_shared<SeqGen>(_redis);
-        _push_outbox = std::make_shared<PushOutbox>(_redis);
-        _es_outbox = std::make_shared<ESOutbox>(_redis);
+        if (!_redis_seeds.empty()) {
+            auto cluster = RedisClusterFactory::create(_redis_seeds, pool_size, keep_alive);
+            _redis_client = std::make_shared<RedisClient>(cluster);
+        } else {
+            auto redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
+            _redis_client = std::make_shared<RedisClient>(redis);
+        }
+        _seq_gen = std::make_shared<SeqGen>(_redis_client);
+        _push_outbox = std::make_shared<PushOutbox>(_redis_client);
+        _es_outbox = std::make_shared<ESOutbox>(_redis_client);
     }
     void make_es_object(const std::vector<std::string> &hosts) {
         _es_client = ESClientFactory::create(hosts);
@@ -1087,7 +1095,8 @@ private:
 
 private:
     std::shared_ptr<odb::core::database> _odb_db;
-    std::shared_ptr<sw::redis::Redis> _redis;
+    std::string _redis_seeds;
+    RedisClient::ptr _redis_client;
     std::shared_ptr<elasticlient::Client> _es_client;
     MQClient::ptr _mq_client;
     Registry::ptr _registry;

--- a/presence/source/presence_server.cc
+++ b/presence/source/presence_server.cc
@@ -12,6 +12,7 @@ DEFINE_string(push_service, "/service/push_service", "Push 子服务名称（用
 DEFINE_string(instance_name, "/presence_service/instance", "Presence 服务实例标识");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis服务器访问地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32(redis_port, 6379, "Redis服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis默认库号");
 DEFINE_bool(redis_keep_alive, true, "Redis长连接保活");
@@ -23,9 +24,15 @@ int main(int argc, char *argv[])
     google::ParseCommandLineFlags(&argc, &argv, true);
     chatnow::init_logger(FLAGS_run_mode, FLAGS_log_file, FLAGS_log_level);
 
-    // Redis
-    auto redis = std::make_shared<sw::redis::Redis>(
-        fmt::format("tcp://{}:{}/{}", FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db));
+    // Redis — 支持单机与 Cluster 双模式
+    std::shared_ptr<chatnow::RedisClient> redis;
+    if (!FLAGS_redis_seeds.empty()) {
+        auto cluster = chatnow::RedisClusterFactory::create(FLAGS_redis_seeds);
+        redis = std::make_shared<chatnow::RedisClient>(cluster);
+    } else {
+        auto r = chatnow::RedisClientFactory::create(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive);
+        redis = std::make_shared<chatnow::RedisClient>(r);
+    }
 
     // 服务发现
     auto channels = std::make_shared<chatnow::ServiceManager>();

--- a/presence/source/presence_server.h
+++ b/presence/source/presence_server.h
@@ -36,7 +36,7 @@ class PresenceAggregator {
 public:
     using ptr = std::shared_ptr<PresenceAggregator>;
 
-    explicit PresenceAggregator(std::shared_ptr<sw::redis::Redis> redis)
+    explicit PresenceAggregator(RedisClient::ptr redis)
         : _redis(std::move(redis)) {}
 
     Presence aggregate(const std::string& uid) {
@@ -152,12 +152,12 @@ public:
     }
 
 private:
-    std::shared_ptr<sw::redis::Redis> _redis;
+    RedisClient::ptr _redis;
 };
 
 class PresenceServiceImpl : public PresenceService {
 public:
-    PresenceServiceImpl(std::shared_ptr<sw::redis::Redis> redis,
+    PresenceServiceImpl(RedisClient::ptr redis,
                         const ServiceManager::ptr& channels,
                         const std::string& push_service_name)
         : _redis(std::move(redis)),
@@ -365,7 +365,7 @@ private:
         }
     }
 
-    std::shared_ptr<sw::redis::Redis> _redis;
+    RedisClient::ptr _redis;
     PresenceAggregator::ptr _aggregator;
     ServiceManager::ptr _channels;
     std::string _push_service_name;

--- a/push/source/push_server.cc
+++ b/push/source/push_server.cc
@@ -62,6 +62,7 @@ int main(int argc, char *argv[])
     psb.make_reg_object(FLAGS_registry_host, FLAGS_base_service + FLAGS_instance_name, FLAGS_access_host);
     psb.set_resend_params(FLAGS_resend_batch, FLAGS_resend_max_age_sec);
     psb.set_etcd_client(std::make_shared<etcd::Client>(FLAGS_registry_host));
+    psb.set_push_service_dir(FLAGS_base_service + FLAGS_push_service);
     psb.make_cross_reaper_election();
     psb.make_local_cache();
     psb.make_rpc_object(FLAGS_listen_port, FLAGS_rpc_timeout, FLAGS_rpc_threads, FLAGS_ws_port);

--- a/push/source/push_server.cc
+++ b/push/source/push_server.cc
@@ -19,6 +19,7 @@ DEFINE_string(message_service, "/service/message_service", "消息存储子服�
 DEFINE_string(push_service, "/service/push_service", "推送子服务名称（自身，便于跨实例转发）");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis 服务器访问地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32(redis_port, 6379, "Redis 端口");
 DEFINE_int32(redis_db, 0, "Redis 库号");
 DEFINE_bool(redis_keep_alive, true, "Redis 长连接");
@@ -52,6 +53,7 @@ int main(int argc, char *argv[])
     jwt_cfg.access_ttl_sec = 7200;
     psb.make_jwt_object(jwt_cfg);
 
+    psb.set_redis_seeds(FLAGS_redis_seeds);
     psb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db,
                           FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     psb.make_mq_object(FLAGS_mq_user, FLAGS_mq_pswd, FLAGS_mq_host,

--- a/push/source/push_server.cc
+++ b/push/source/push_server.cc
@@ -61,6 +61,8 @@ int main(int argc, char *argv[])
     psb.make_discovery_object(FLAGS_registry_host, FLAGS_base_service, FLAGS_message_service, FLAGS_push_service);
     psb.make_reg_object(FLAGS_registry_host, FLAGS_base_service + FLAGS_instance_name, FLAGS_access_host);
     psb.set_resend_params(FLAGS_resend_batch, FLAGS_resend_max_age_sec);
+    psb.set_etcd_client(std::make_shared<etcd::Client>(FLAGS_registry_host));
+    psb.make_cross_reaper_election();
     psb.make_rpc_object(FLAGS_listen_port, FLAGS_rpc_timeout, FLAGS_rpc_threads, FLAGS_ws_port);
 
     auto server = psb.build();

--- a/push/source/push_server.cc
+++ b/push/source/push_server.cc
@@ -63,6 +63,7 @@ int main(int argc, char *argv[])
     psb.set_resend_params(FLAGS_resend_batch, FLAGS_resend_max_age_sec);
     psb.set_etcd_client(std::make_shared<etcd::Client>(FLAGS_registry_host));
     psb.make_cross_reaper_election();
+    psb.make_local_cache();
     psb.make_rpc_object(FLAGS_listen_port, FLAGS_rpc_timeout, FLAGS_rpc_threads, FLAGS_ws_port);
 
     auto server = psb.build();

--- a/push/source/push_server.h
+++ b/push/source/push_server.h
@@ -2,6 +2,7 @@
 
 #include "connection.hpp"
 #include "infra/etcd.hpp"
+#include "infra/leader_election.hpp"
 #include "infra/logger.hpp"
 #include "mq/channel.hpp"
 #include "mq/rabbitmq.hpp"
@@ -44,7 +45,8 @@ public:
                     const CrossInstanceOutbox::ptr &cross_outbox,
                     const std::string &instance_id,
                     const std::string &message_service_name,
-                    const ServiceManager::ptr &channels)
+                    const ServiceManager::ptr &channels,
+                    LeaderElection::ptr cross_reaper_election = nullptr)
         : _connections(connections),
           _jwt_codec(jwt_codec),
           _redis(redis),
@@ -53,7 +55,8 @@ public:
           _cross_outbox(cross_outbox),
           _instance_id(instance_id),
           _message_service_name(message_service_name),
-          _mm_channels(channels) {}
+          _mm_channels(channels),
+          _cross_reaper_election(std::move(cross_reaper_election)) {}
 
     void set_resend_params(long batch, long max_age_sec) {
         _resend_batch = batch;
@@ -468,14 +471,13 @@ public:
     void start_cross_outbox_reaper(const std::string &owner) {
         if (!_cross_outbox || !_mm_channels) return;
         constexpr int kReapIntervalSec = 5;
-        constexpr int kLeaseTtlSec = 30;
         constexpr int kBatchLimit = 50;
         _cross_reaper_running.store(true);
         _cross_reaper_owner = owner;
-        _cross_reaper_thread = std::thread([this, kReapIntervalSec, kLeaseTtlSec, kBatchLimit]() {
+        _cross_reaper_thread = std::thread([this, kReapIntervalSec, kBatchLimit]() {
             while (_cross_reaper_running.load()) {
                 try {
-                    if (!_cross_outbox->try_acquire_reaper_lease(_cross_reaper_owner, kLeaseTtlSec)) {
+                    if (!_cross_reaper_election || !_cross_reaper_election->is_leader()) {
                         std::this_thread::sleep_for(std::chrono::seconds(kReapIntervalSec));
                         continue;
                     }
@@ -542,7 +544,6 @@ public:
                 }
                 std::this_thread::sleep_for(std::chrono::seconds(kReapIntervalSec));
             }
-            if (_cross_outbox) _cross_outbox->release_reaper_lease(_cross_reaper_owner);
             LOG_INFO("CrossInstanceOutbox reaper 已停止");
         });
     }
@@ -550,6 +551,7 @@ public:
     void stop_cross_outbox_reaper() {
         _cross_reaper_running.store(false);
         if (_cross_reaper_thread.joinable()) _cross_reaper_thread.join();
+        if (_cross_reaper_election) _cross_reaper_election->stop();
     }
 
 private:
@@ -631,6 +633,7 @@ private:
     std::atomic<bool> _cross_reaper_running{false};
     std::thread _cross_reaper_thread;
     std::string _cross_reaper_owner;
+    LeaderElection::ptr _cross_reaper_election;
 };
 
 class PushServer
@@ -804,6 +807,15 @@ public:
         _resend_max_age_sec = max_age_sec;
     }
     void set_reaper_owner(const std::string &owner) { _reaper_owner = owner; }
+    void set_etcd_client(std::shared_ptr<etcd::Client> etcd) { _etcd_client = etcd; }
+
+    void make_cross_reaper_election() {
+        if (!_etcd_client) return;
+        _cross_reaper_election = std::make_shared<LeaderElection>(
+            _etcd_client, "/chatnow/reaper/cross_outbox", _instance_id, 30,
+            []() { LOG_INFO("CrossOutbox reaper 成为 leader"); },
+            []() { LOG_INFO("CrossOutbox reaper 失去 leader"); });
+    }
 
     void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads, uint16_t ws_port) {
         if (!_redis_client) { LOG_ERROR("Push: Redis 未初始化"); abort(); }
@@ -812,7 +824,8 @@ public:
         _rpc_server = std::make_shared<brpc::Server>();
         _push_service = new PushServiceImpl(
             _connections, _jwt_codec, _redis_client, _online_route, _unacked, _cross_outbox,
-            _instance_id, _message_service_name, _mm_channels);
+            _instance_id, _message_service_name, _mm_channels,
+            _cross_reaper_election);
         _push_service->set_resend_params(_resend_batch, _resend_max_age_sec);
         int ret = _rpc_server->AddService(_push_service, brpc::ServiceOwnership::SERVER_OWNS_SERVICE);
         if (ret == -1) { LOG_ERROR("Push: AddService 失败"); abort(); }
@@ -844,6 +857,7 @@ public:
         };
         _push_subscriber->consume(std::move(callback));
 
+        if (_cross_reaper_election) _cross_reaper_election->start();
         std::string owner = _reaper_owner.empty()
             ? std::to_string(::getpid()) : _reaper_owner;
         _push_service->start_cross_outbox_reaper(owner);
@@ -881,6 +895,8 @@ private:
     int _resend_batch{50};
     int _resend_max_age_sec{5};
     std::string _reaper_owner;
+    std::shared_ptr<etcd::Client> _etcd_client;
+    LeaderElection::ptr _cross_reaper_election;
 
     Connection::ptr _connections;
     server_t _ws_server;

--- a/push/source/push_server.h
+++ b/push/source/push_server.h
@@ -38,7 +38,7 @@ class PushServiceImpl : public PushService
 public:
     PushServiceImpl(const Connection::ptr &connections,
                     const std::shared_ptr<chatnow::auth::JwtCodec> &jwt_codec,
-                    const std::shared_ptr<sw::redis::Redis> &redis,
+                    const RedisClient::ptr &redis,
                     const OnlineRoute::ptr &online_route,
                     const UnackedPush::ptr &unacked,
                     const CrossInstanceOutbox::ptr &cross_outbox,
@@ -619,7 +619,7 @@ private:
 
     Connection::ptr _connections;
     std::shared_ptr<chatnow::auth::JwtCodec> _jwt_codec;
-    std::shared_ptr<sw::redis::Redis> _redis;
+    RedisClient::ptr _redis;
     OnlineRoute::ptr _online_route;
     UnackedPush::ptr _unacked;
     CrossInstanceOutbox::ptr _cross_outbox;
@@ -684,13 +684,21 @@ public:
         _jwt_codec = std::make_shared<chatnow::auth::JwtCodec>(config);
     }
 
+    void set_redis_seeds(const std::string &seeds) { _redis_seeds = seeds; }
+
     void make_redis_object(const std::string &host, uint16_t port, int db,
                            bool keep_alive, int pool_size)
     {
-        _redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
-        _online_route = std::make_shared<OnlineRoute>(_redis);
-        _unacked      = std::make_shared<UnackedPush>(_redis);
-        _cross_outbox = std::make_shared<CrossInstanceOutbox>(_redis);
+        if (!_redis_seeds.empty()) {
+            auto cluster = RedisClusterFactory::create(_redis_seeds, pool_size, keep_alive);
+            _redis_client = std::make_shared<RedisClient>(cluster);
+        } else {
+            auto redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
+            _redis_client = std::make_shared<RedisClient>(redis);
+        }
+        _online_route = std::make_shared<OnlineRoute>(_redis_client);
+        _unacked      = std::make_shared<UnackedPush>(_redis_client);
+        _cross_outbox = std::make_shared<CrossInstanceOutbox>(_redis_client);
     }
 
     void make_discovery_object(const std::string &reg_host,
@@ -798,12 +806,12 @@ public:
     void set_reaper_owner(const std::string &owner) { _reaper_owner = owner; }
 
     void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads, uint16_t ws_port) {
-        if (!_redis) { LOG_ERROR("Push: Redis 未初始化"); abort(); }
+        if (!_redis_client) { LOG_ERROR("Push: Redis 未初始化"); abort(); }
         if (!_mm_channels) { LOG_ERROR("Push: 信道管理未初始化"); abort(); }
         _connections = std::make_shared<Connection>();
         _rpc_server = std::make_shared<brpc::Server>();
         _push_service = new PushServiceImpl(
-            _connections, _jwt_codec, _redis, _online_route, _unacked, _cross_outbox,
+            _connections, _jwt_codec, _redis_client, _online_route, _unacked, _cross_outbox,
             _instance_id, _message_service_name, _mm_channels);
         _push_service->set_resend_params(_resend_batch, _resend_max_age_sec);
         int ret = _rpc_server->AddService(_push_service, brpc::ServiceOwnership::SERVER_OWNS_SERVICE);
@@ -852,7 +860,8 @@ public:
     }
 
 private:
-    std::shared_ptr<sw::redis::Redis> _redis;
+    std::string _redis_seeds;
+    RedisClient::ptr _redis_client;
     std::shared_ptr<chatnow::auth::JwtCodec> _jwt_codec;
     OnlineRoute::ptr _online_route;
     UnackedPush::ptr _unacked;

--- a/push/source/push_server.h
+++ b/push/source/push_server.h
@@ -501,7 +501,7 @@ private:
             auto cached = _local_route_cache->get(cache_key);
             if (cached.has_value()) {
                 lk.unlock();
-                if (_inflight_registry) _inflight_registry->release(guard.key);
+                guard = InflightRegistry::Guard{};
                 return *cached;
             }
         }
@@ -518,7 +518,7 @@ private:
         }
 
         lk.unlock();
-        if (_inflight_registry) _inflight_registry->release(guard.key);
+        guard = InflightRegistry::Guard{};
         return route;
     }
 

--- a/push/source/push_server.h
+++ b/push/source/push_server.h
@@ -16,6 +16,9 @@
 #include "error/error_codes.hpp"
 #include "error/service_error.hpp"
 #include "utils/brpc_closure.hpp"
+#include "utils/local_cache.hpp"
+#include "utils/inflight.hpp"
+#include "utils/random_ttl.hpp"
 #include "common/types.pb.h"
 #include "common/error.pb.h"
 #include "common/envelope.pb.h"
@@ -34,6 +37,11 @@
 
 namespace chatnow::push {
 
+struct RouteEntry {
+    std::vector<std::string> device_ids;
+    std::unordered_map<std::string, std::string> device_to_instance;
+};
+
 class PushServiceImpl : public PushService
 {
 public:
@@ -46,7 +54,9 @@ public:
                     const std::string &instance_id,
                     const std::string &message_service_name,
                     const ServiceManager::ptr &channels,
-                    LeaderElection::ptr cross_reaper_election = nullptr)
+                    LeaderElection::ptr cross_reaper_election = nullptr,
+                    LocalCache<RouteEntry>::ptr local_route_cache = nullptr,
+                    InflightRegistry::ptr inflight_registry = nullptr)
         : _connections(connections),
           _jwt_codec(jwt_codec),
           _redis(redis),
@@ -56,7 +66,9 @@ public:
           _instance_id(instance_id),
           _message_service_name(message_service_name),
           _mm_channels(channels),
-          _cross_reaper_election(std::move(cross_reaper_election)) {}
+          _cross_reaper_election(std::move(cross_reaper_election)),
+          _local_route_cache(std::move(local_route_cache)),
+          _inflight_registry(std::move(inflight_registry)) {}
 
     void set_resend_params(long batch, long max_age_sec) {
         _resend_batch = batch;
@@ -99,8 +111,8 @@ public:
             }
 
             int delivered = 0;
-            auto devices = _online_route->devices(request->user_id());
-            for (const auto &did : devices) {
+            auto route = resolve_route(request->user_id());
+            for (const auto &did : route.device_ids) {
                 if (filter_devices && target_dids.find(did) == target_dids.end()) continue;
                 if (_local_send(request->user_id(), did, payload) > 0) ++delivered;
             }
@@ -108,7 +120,7 @@ public:
             if (request->has_user_seq() && _unacked) {
                 std::string payload_b64 = _utils_base64_encode(payload);
                 long long now_ts = static_cast<long long>(time(nullptr));
-                for (const auto &did : devices) {
+                for (const auto &did : route.device_ids) {
                     if (filter_devices && target_dids.find(did) == target_dids.end()) continue;
                     _unacked->push(request->user_id(), did,
                                    request->user_seq(), payload_b64, now_ts);
@@ -155,8 +167,8 @@ public:
             int total = 0;
             long long now_ts = static_cast<long long>(time(nullptr));
             for (const auto &uid : request->user_id_list()) {
-                auto devices = _online_route->devices(uid);
-                for (const auto &did : devices) {
+                auto route = resolve_route(uid);
+                for (const auto &did : route.device_ids) {
                     std::string payload;
                     if (is_chat_msg) {
                         NotifyMessage per_user = base_notify;
@@ -218,13 +230,13 @@ public:
         std::vector<std::string> remote_uids;
         remote_uids.reserve(internal_msg.member_id_list_size());
         for (const auto &uid : internal_msg.member_id_list()) {
-            auto devices = _online_route ? _online_route->devices(uid)
-                                         : std::vector<std::string>{};
-            if (devices.empty()) { remote_uids.push_back(uid); continue; }
+            auto route = _online_route ? resolve_route(uid) : RouteEntry{};
+            if (route.device_ids.empty()) { remote_uids.push_back(uid); continue; }
 
             bool any_local = false;
-            for (const auto &did : devices) {
-                std::string inst = _online_route->device_instance(uid, did);
+            for (const auto &did : route.device_ids) {
+                auto it = route.device_to_instance.find(did);
+                std::string inst = (it != route.device_to_instance.end()) ? it->second : "";
                 if (inst == _instance_id) {
                     auto it = uid2seq.find(uid);
                     if (it != uid2seq.end()) {
@@ -252,10 +264,10 @@ public:
         // 2) 跨实例：按 Push 实例 ID 分组
         std::unordered_map<std::string, std::vector<std::string>> peer_to_uids;
         for (const auto &uid : remote_uids) {
-            auto devices = _online_route ? _online_route->devices(uid)
-                                         : std::vector<std::string>{};
-            for (const auto &did : devices) {
-                std::string peer = _online_route->device_instance(uid, did);
+            auto route = _online_route ? resolve_route(uid) : RouteEntry{};
+            for (const auto &did : route.device_ids) {
+                auto it = route.device_to_instance.find(did);
+                std::string peer = (it != route.device_to_instance.end()) ? it->second : "";
                 if (peer.empty() || peer == _instance_id) continue;
                 auto &vec = peer_to_uids[peer];
                 if (std::find(vec.begin(), vec.end(), uid) == vec.end())
@@ -410,8 +422,8 @@ private:
         const std::string uid = hb.user_id();
         if (uid.empty()) return;
 
-        auto devices = _online_route->devices(uid);
-        for (const auto &did : devices) {
+        auto route = resolve_route(uid);
+        for (const auto &did : route.device_ids) {
             auto pending = _unacked->peek_due(uid, did, _resend_batch, _resend_max_age_sec);
             if (pending.empty()) continue;
 
@@ -445,6 +457,47 @@ private:
         } catch (std::exception &e) {
             LOG_WARN("Presence 写入失败 uid={} did={}: {}", uid, did, e.what());
         }
+    }
+
+    RouteEntry resolve_route(const std::string &uid) {
+        std::string cache_key = "route:" + uid;
+
+        //  L1 hit → fast path (~ns)
+        if (_local_route_cache) {
+            auto cached = _local_route_cache->get(cache_key);
+            if (cached.has_value()) return *cached;
+        }
+
+        //  L1 miss → acquire InflightRegistry per-key lock
+        auto guard = _inflight_registry ? _inflight_registry->acquire(cache_key)
+                                        : InflightRegistry::Guard{};
+        std::shared_ptr<std::mutex> lock_mu = guard.mu;
+        std::unique_lock<std::mutex> lk(lock_mu ? *lock_mu : _dummy_mu_);
+
+        //  Double-check L1 (another thread may have just finished warm)
+        if (_local_route_cache) {
+            auto cached = _local_route_cache->get(cache_key);
+            if (cached.has_value()) {
+                lk.unlock();
+                if (_inflight_registry) _inflight_registry->release(guard.key);
+                return *cached;
+            }
+        }
+
+        //  L2 Redis: hgetall + build RouteEntry
+        RouteEntry route;
+        auto devices = _online_route->devices(uid);
+        route.device_ids = std::move(devices);
+        for (const auto &did : route.device_ids) {
+            route.device_to_instance[did] = _online_route->device_instance(uid, did);
+        }
+        if (_local_route_cache) {
+            _local_route_cache->set(cache_key, route, randomized_ttl(std::chrono::seconds(2)));
+        }
+
+        lk.unlock();
+        if (_inflight_registry) _inflight_registry->release(guard.key);
+        return route;
     }
 
     /* brief: 本实例直接通过 WS 下发；返回送达连接数 */
@@ -501,10 +554,10 @@ public:
                         // 按实例分组重发
                         std::unordered_map<std::string, std::vector<std::string>> peer_to_uids;
                         for (const auto &uid : uids) {
-                            auto devices = _online_route ? _online_route->devices(uid)
-                                                         : std::vector<std::string>{};
-                            for (const auto &did : devices) {
-                                std::string inst = _online_route->device_instance(uid, did);
+                            auto route = _online_route ? resolve_route(uid) : RouteEntry{};
+                            for (const auto &did : route.device_ids) {
+                                auto it = route.device_to_instance.find(did);
+                                std::string inst = (it != route.device_to_instance.end()) ? it->second : "";
                                 if (inst == _instance_id) continue;
                                 peer_to_uids[inst].push_back(uid);
                                 break;
@@ -634,6 +687,9 @@ private:
     std::thread _cross_reaper_thread;
     std::string _cross_reaper_owner;
     LeaderElection::ptr _cross_reaper_election;
+    LocalCache<RouteEntry>::ptr _local_route_cache;
+    InflightRegistry::ptr _inflight_registry;
+    std::mutex _dummy_mu_;
 };
 
 class PushServer
@@ -817,6 +873,11 @@ public:
             []() { LOG_INFO("CrossOutbox reaper 失去 leader"); });
     }
 
+    void make_local_cache() {
+        _local_route_cache = std::make_shared<LocalCache<RouteEntry>>(16384);
+        _inflight_registry = std::make_shared<InflightRegistry>();
+    }
+
     void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads, uint16_t ws_port) {
         if (!_redis_client) { LOG_ERROR("Push: Redis 未初始化"); abort(); }
         if (!_mm_channels) { LOG_ERROR("Push: 信道管理未初始化"); abort(); }
@@ -825,7 +886,7 @@ public:
         _push_service = new PushServiceImpl(
             _connections, _jwt_codec, _redis_client, _online_route, _unacked, _cross_outbox,
             _instance_id, _message_service_name, _mm_channels,
-            _cross_reaper_election);
+            _cross_reaper_election, _local_route_cache, _inflight_registry);
         _push_service->set_resend_params(_resend_batch, _resend_max_age_sec);
         int ret = _rpc_server->AddService(_push_service, brpc::ServiceOwnership::SERVER_OWNS_SERVICE);
         if (ret == -1) { LOG_ERROR("Push: AddService 失败"); abort(); }
@@ -897,6 +958,8 @@ private:
     std::string _reaper_owner;
     std::shared_ptr<etcd::Client> _etcd_client;
     LeaderElection::ptr _cross_reaper_election;
+    LocalCache<RouteEntry>::ptr _local_route_cache;
+    InflightRegistry::ptr _inflight_registry;
 
     Connection::ptr _connections;
     server_t _ws_server;

--- a/push/source/push_server.h
+++ b/push/source/push_server.h
@@ -363,6 +363,28 @@ public:
         }
     }
 
+    void shutdown_cleanup() {
+        LOG_INFO("Push 关停: 开始清理 OnlineRoute...");
+        // SCAN all online keys and unbind those belonging to this instance
+        long long cursor = 0;
+        do {
+            std::vector<std::string> keys;
+            cursor = _redis->scan(cursor, "im:online:*", 100, std::back_inserter(keys));
+            for (const auto &key : keys) {
+                std::string uid = key.substr(std::string("im:online:").size());
+                std::unordered_map<std::string, std::string> device_map;
+                _redis->hgetall(key, std::inserter(device_map, device_map.end()));
+                for (const auto &[did, instance] : device_map) {
+                    if (instance == _instance_id) {
+                        _online_route->unbind(uid, did, _instance_id);
+                    }
+                }
+                if (_local_route_cache) _local_route_cache->invalidate("route:" + uid);
+            }
+        } while (cursor != 0);
+        LOG_INFO("Push 关停: OnlineRoute + L1 缓存已清理");
+    }
+
     /* brief: 给特定设备推送 KICKED 通知 */
     void publish_kicked(const std::string &uid, const std::string &device_id,
                         NotifyType reason, const std::string &msg) {
@@ -607,6 +629,56 @@ public:
         if (_cross_reaper_election) _cross_reaper_election->stop();
     }
 
+    const auto& connections() const { return _connections; }
+
+    void reap_stale_routes_(const std::string &push_service_dir,
+                            std::shared_ptr<etcd::Client> etcd_client,
+                            LeaderElection::ptr stale_reaper_election,
+                            std::atomic<bool> *running) {
+        while (running && running->load()) {
+            std::this_thread::sleep_for(std::chrono::seconds(30));
+            if (!stale_reaper_election || !stale_reaper_election->is_leader())
+                continue;
+
+            std::vector<std::string> online_instances;
+            try {
+                auto resp = etcd_client->ls(push_service_dir).get();
+                if (resp.is_ok()) {
+                    for (size_t i = 0; i < resp.keys().size(); ++i)
+                        online_instances.push_back(resp.value(i).as_string());
+                }
+            } catch (std::exception &e) {
+                LOG_WARN("StaleRoute reaper: etcd ls 失败: {}", e.what());
+                continue;
+            }
+
+            std::vector<std::pair<std::string, std::string>> stale_entries;
+            long long cursor = 0;
+            do {
+                std::vector<std::string> keys;
+                cursor = _redis->scan(cursor, "im:online:*", 100, std::back_inserter(keys));
+                for (const auto &key : keys) {
+                    std::string uid = key.substr(std::string("im:online:").size());
+                    std::unordered_map<std::string, std::string> device_map;
+                    _redis->hgetall(key, std::inserter(device_map, device_map.end()));
+                    for (const auto &[did, instance] : device_map) {
+                        if (std::find(online_instances.begin(), online_instances.end(), instance)
+                            == online_instances.end()) {
+                            stale_entries.emplace_back(uid, did);
+                        }
+                    }
+                }
+            } while (cursor != 0);
+
+            for (const auto &[uid, did] : stale_entries) {
+                _online_route->unbind(uid, did, "");
+                if (_local_route_cache) _local_route_cache->invalidate("route:" + uid);
+            }
+            if (!stale_entries.empty())
+                LOG_INFO("StaleRoute reaper: 移除 {} 条僵死路由", stale_entries.size());
+        }
+    }
+
 private:
     void _parse_outbox_member(const std::string &member,
                                std::string &b64,
@@ -701,9 +773,10 @@ public:
                const std::shared_ptr<brpc::Server> &rpc,
                server_t *ws_server,
                const MQClient::ptr &mq_client,
-               const Subscriber::ptr &push_subscriber)
+               const Subscriber::ptr &push_subscriber,
+               PushServiceImpl *push_service = nullptr)
         : _service_discover(disc), _reg_client(reg), _rpc_server(rpc), _ws_server(ws_server),
-          _mq_client(mq_client), _push_subscriber(push_subscriber) {}
+          _mq_client(mq_client), _push_subscriber(push_subscriber), _push_service(push_service) {}
     ~PushServer() = default;
 
     void start() {
@@ -720,6 +793,12 @@ public:
         _push_subscriber.reset();
         _mq_client.reset();
         _ws_server->stop();
+
+        // 关停清理：遍历连接，主动清理 OnlineRoute 和 L1 缓存
+        if (_push_service) {
+            _push_service->shutdown_cleanup();
+        }
+
         if (_ws_thread.joinable()) _ws_thread.join();
         _rpc_server->Join();
         LOG_INFO("Push 关停完成");
@@ -732,6 +811,7 @@ private:
     server_t *_ws_server;
     MQClient::ptr _mq_client;
     Subscriber::ptr _push_subscriber;
+    PushServiceImpl *_push_service{nullptr};
     std::thread _ws_thread;
 };
 
@@ -878,6 +958,16 @@ public:
         _inflight_registry = std::make_shared<InflightRegistry>();
     }
 
+    void set_push_service_dir(const std::string &dir) { _push_service_dir = dir; }
+
+    void make_stale_reaper_election() {
+        if (!_etcd_client) return;
+        _stale_reaper_election = std::make_shared<LeaderElection>(
+            _etcd_client, "/chatnow/reaper/stale_routes", _instance_id, 30,
+            []() { LOG_INFO("StaleRoute reaper 成为 leader"); },
+            []() { LOG_INFO("StaleRoute reaper 失去 leader"); });
+    }
+
     void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads, uint16_t ws_port) {
         if (!_redis_client) { LOG_ERROR("Push: Redis 未初始化"); abort(); }
         if (!_mm_channels) { LOG_ERROR("Push: 信道管理未初始化"); abort(); }
@@ -922,6 +1012,17 @@ public:
         std::string owner = _reaper_owner.empty()
             ? std::to_string(::getpid()) : _reaper_owner;
         _push_service->start_cross_outbox_reaper(owner);
+
+        // Stale route reaper
+        if (_stale_reaper_election) {
+            _stale_reaper_election->start();
+            _stale_reaper_running = true;
+            _stale_reaper_thread = std::thread([this]() {
+                _push_service->reap_stale_routes_(_push_service_dir, _etcd_client,
+                                                  _stale_reaper_election, &_stale_reaper_running);
+            });
+        }
+
         LOG_INFO("Push 服务启动: rpc_port={} ws_port={}", port, ws_port);
     }
 
@@ -931,7 +1032,8 @@ public:
                                             std::move(_rpc_server),
                                             &_ws_server,
                                             std::move(_mq_client),
-                                            std::move(_push_subscriber));
+                                            std::move(_push_subscriber),
+                                            _push_service);
     }
 
 private:
@@ -960,6 +1062,10 @@ private:
     LeaderElection::ptr _cross_reaper_election;
     LocalCache<RouteEntry>::ptr _local_route_cache;
     InflightRegistry::ptr _inflight_registry;
+    std::string _push_service_dir;
+    LeaderElection::ptr _stale_reaper_election;
+    std::thread _stale_reaper_thread;
+    std::atomic<bool> _stale_reaper_running{false};
 
     Connection::ptr _connections;
     server_t _ws_server;

--- a/push/source/push_server.h
+++ b/push/source/push_server.h
@@ -901,6 +901,7 @@ public:
             if (_connections && _connections->client(conn, uid, did, jti)) {
                 _connections->remove(conn);
                 if (_online_route) _online_route->unbind(uid, did, _instance_id);
+                if (_local_route_cache) _local_route_cache->invalidate("route:" + uid);
                 LOG_DEBUG("WS 关闭 uid={} did={}", uid, did);
             }
         });

--- a/push/source/push_server.h
+++ b/push/source/push_server.h
@@ -366,6 +366,8 @@ public:
     void shutdown_cleanup() {
         LOG_INFO("Push 关停: 开始清理 OnlineRoute...");
         // SCAN all online keys and unbind those belonging to this instance
+        // NOTE: SCAN is per-node in Redis Cluster mode. Only keys on the node
+        // that this connection routes to will be scanned. Fallback: 30s kOnlineTtl auto-expiry.
         long long cursor = 0;
         do {
             std::vector<std::string> keys;
@@ -653,6 +655,8 @@ public:
             }
 
             std::vector<std::pair<std::string, std::string>> stale_entries;
+            // NOTE: SCAN is per-node in Redis Cluster mode. Only keys on the node
+            // that this connection routes to will be scanned. Fallback: 30s kOnlineTtl auto-expiry.
             long long cursor = 0;
             do {
                 std::vector<std::string> keys;

--- a/scripts/prometheus/redis_alerts.yml
+++ b/scripts/prometheus/redis_alerts.yml
@@ -1,0 +1,32 @@
+groups:
+  - name: redis_cluster
+    rules:
+      - alert: RedisNodeDown
+        expr: redis_up{node=~".+"} == 0
+        for: 1m
+        labels: { severity: critical }
+        annotations:
+          summary: "Redis node {{ $labels.node }} down"
+          description: "Redis Cluster node {{ $labels.node }} has been down for >1m"
+
+      - alert: RedisPoolExhausted
+        expr: redis_pool_active >= redis_pool_size
+        for: 1m
+        labels: { severity: critical }
+        annotations:
+          summary: "Redis connection pool exhausted on {{ $labels.instance }}"
+          description: "redis_pool_active ({{ $value }}) >= pool_size, connections saturated"
+
+      - alert: LeaderElectionFrequentChange
+        expr: rate(leader_election_changes_total[10m]) > 2
+        for: 1m
+        labels: { severity: warning }
+        annotations:
+          summary: "Leader election changing frequently (>2x in 10min)"
+
+      - alert: LocalCacheHitRateDrop
+        expr: rate(local_cache_miss_total[5m]) > 3 * rate(local_cache_miss_total[5m] offset 30m)
+        for: 5m
+        labels: { severity: warning }
+        annotations:
+          summary: "Local cache miss rate spiked 3x vs 30min ago"

--- a/transmite/source/transmite_server.cc
+++ b/transmite/source/transmite_server.cc
@@ -56,6 +56,7 @@ int main(int argc, char *argv[])
     tsb.set_redis_seeds(FLAGS_redis_seeds);
     tsb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     tsb.set_instance_owner(FLAGS_access_host);
+    tsb.set_etcd_client(std::make_shared<etcd::Client>(FLAGS_registry_host));
     tsb.make_id_generator_object(FLAGS_instance_num, FLAGS_epoch_ms, FLAGS_wait_on_clock_backwards);
     tsb.make_mq_object(FLAGS_mq_user, FLAGS_mq_pswd, FLAGS_mq_host, FLAGS_mq_msg_exchange, FLAGS_mq_msg_queue, FLAGS_mq_msg_binding_key);
     tsb.make_discovery_object(FLAGS_registry_host, FLAGS_base_service, FLAGS_identity_service, FLAGS_conversation_service, FLAGS_message_service);

--- a/transmite/source/transmite_server.cc
+++ b/transmite/source/transmite_server.cc
@@ -57,6 +57,7 @@ int main(int argc, char *argv[])
     tsb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     tsb.set_instance_owner(FLAGS_access_host);
     tsb.set_etcd_client(std::make_shared<etcd::Client>(FLAGS_registry_host));
+    tsb.make_local_cache();
     tsb.make_id_generator_object(FLAGS_instance_num, FLAGS_epoch_ms, FLAGS_wait_on_clock_backwards);
     tsb.make_mq_object(FLAGS_mq_user, FLAGS_mq_pswd, FLAGS_mq_host, FLAGS_mq_msg_exchange, FLAGS_mq_msg_queue, FLAGS_mq_msg_binding_key);
     tsb.make_discovery_object(FLAGS_registry_host, FLAGS_base_service, FLAGS_identity_service, FLAGS_conversation_service, FLAGS_message_service);

--- a/transmite/source/transmite_server.cc
+++ b/transmite/source/transmite_server.cc
@@ -22,6 +22,7 @@ DEFINE_string(conversation_service, "/service/conversation_service", "会话管�
 DEFINE_string(message_service, "/service/message_service", "消息存储子服务名称（用于幂等查询）");
 
 DEFINE_string(redis_host, "127.0.0.1", "Redis 服务器访问地址");
+DEFINE_string(redis_seeds, "", "Redis Cluster 种子节点（逗号分隔，如 host1:6379,host2:6379）");
 DEFINE_int32(redis_port, 6379, "Redis 服务器访问端口");
 DEFINE_int32(redis_db, 0, "Redis 选择的库");
 DEFINE_bool(redis_keep_alive, true, "Redis 长连接");
@@ -52,6 +53,7 @@ int main(int argc, char *argv[])
 
     chatnow::TransmiteServerBuilder tsb;
     // 注意：先初始化 Redis（worker_id 自动分配依赖 Redis），再初始化 ID 生成器
+    tsb.set_redis_seeds(FLAGS_redis_seeds);
     tsb.make_redis_object(FLAGS_redis_host, FLAGS_redis_port, FLAGS_redis_db, FLAGS_redis_keep_alive, FLAGS_redis_pool_size);
     tsb.set_instance_owner(FLAGS_access_host);
     tsb.make_id_generator_object(FLAGS_instance_num, FLAGS_epoch_ms, FLAGS_wait_on_clock_backwards);

--- a/transmite/source/transmite_server.h
+++ b/transmite/source/transmite_server.h
@@ -14,6 +14,10 @@
 #include "infra/snowflake.hpp"
 #include "dao/data_redis.hpp"
 #include "utils/worker_id.hpp"
+#include "utils/local_cache.hpp"
+#include "utils/inflight.hpp"
+#include "utils/redis_mutex.hpp"
+#include "utils/random_ttl.hpp"
 #include "common/error.pb.h"
 #include "common/envelope.pb.h"
 #include "identity/identity_service.pb.h"
@@ -47,7 +51,10 @@ public:
                         const SeqGen::ptr &seq_gen,
                         const Members::ptr &members_cache,
                         const RateLimiter::ptr &rate_limiter,
-                        const RedisClient::ptr &redis)
+                        const RedisClient::ptr &redis,
+                        LocalCache<std::vector<std::string>>::ptr local_members_cache = nullptr,
+                        LocalCache<std::string>::ptr local_user_cache = nullptr,
+                        InflightRegistry::ptr inflight_registry = nullptr)
                         : _identity_service_name(identity_service_name),
                         _conversation_service_name(conversation_service_name),
                         _message_service_name(message_service_name),
@@ -59,7 +66,10 @@ public:
                         _seq_gen(seq_gen),
                         _members_cache(members_cache),
                         _rate_limiter(rate_limiter),
-                        _redis(redis) {}
+                        _redis(redis),
+                        _local_members_cache(std::move(local_members_cache)),
+                        _local_user_cache(std::move(local_user_cache)),
+                        _inflight_registry(std::move(inflight_registry)) {}
     ~TransmiteServiceImpl() = default;
 
     void SendMessage(google::protobuf::RpcController *controller,
@@ -164,13 +174,8 @@ public:
             return err_response(rid, chatnow::error::kSystemUnavailable, "依赖服务暂不可用");
         }
 
-        // 成员列表：先查 Redis 缓存，未命中再 RPC + 回填
-        std::vector<std::string> member_id_list;
-        bool members_from_cache = false;
-        if (_members_cache) {
-            member_id_list = _members_cache->list(chat_ssid);
-            if (!member_id_list.empty()) members_from_cache = true;
-        }
+        // 成员列表：L1 → InflightRegistry → L2 Redis → RPC
+        std::vector<std::string> member_id_list = resolve_members(chat_ssid);
 
         chatnow::identity::IdentityService_Stub identity_stub(identity_channel.get());
         chatnow::identity::GetProfileReq profile_req;
@@ -181,10 +186,10 @@ public:
         chatnow::auth::forward_auth_metadata(static_cast<brpc::Controller*>(controller), &profile_cntl);
         identity_stub.GetProfile(&profile_cntl, &profile_req, &profile_rsp, brpc::DoNothing());
 
-        // 成员列表未命中缓存：RPC 拉取
+        // 成员列表未命中缓存：RPC 拉取 + warm
         ::chatnow::conversation::GetMemberIdsRsp member_rsp;
         brpc::Controller member_cntl;
-        if (!members_from_cache) {
+        if (member_id_list.empty()) {
             auto conv_channel = _mm_channels->choose(_conversation_service_name);
             if (!conv_channel) {
                 brpc::Join(profile_cntl.call_id());
@@ -205,7 +210,7 @@ public:
                 return err_response(rid, chatnow::error::kSystemUnavailable, "获取群成员失败");
             }
             for (const auto &m : member_rsp.member_ids()) member_id_list.push_back(m);
-            if (_members_cache) _members_cache->warm(chat_ssid, member_id_list);
+            warm_members_cache(chat_ssid, member_id_list);
         }
 
         brpc::Join(profile_cntl.call_id());
@@ -330,6 +335,81 @@ public:
             }
         }
     }
+
+    std::vector<std::string> resolve_members(const std::string &chat_session_id) {
+        std::string mkey = "members:" + chat_session_id;
+
+        if (_local_members_cache) {
+            auto local = _local_members_cache->get(mkey);
+            if (local.has_value()) {
+                auto &members = *local;
+                if (members.size() == 1 && members[0] == "__sentinel__")
+                    return {};
+                return members;
+            }
+        }
+
+        auto guard = _inflight_registry ? _inflight_registry->acquire(chat_session_id)
+                                        : InflightRegistry::Guard{};
+        std::shared_ptr<std::mutex> lock_mu = guard.mu;
+        std::unique_lock<std::mutex> lk(lock_mu ? *lock_mu : _dummy_mu_);
+
+        if (_local_members_cache) {
+            auto local = _local_members_cache->get(mkey);
+            if (local.has_value()) {
+                lk.unlock();
+                if (_inflight_registry) _inflight_registry->release(guard.key);
+                auto &members = *local;
+                if (members.size() == 1 && members[0] == "__sentinel__") return {};
+                return members;
+            }
+        }
+
+        auto members = _members_cache->list(chat_session_id);
+        if (!members.empty()) {
+            if (members.size() == 1 && members[0] == "__sentinel__") {
+                if (_local_members_cache)
+                    _local_members_cache->set(mkey, {"__sentinel__"}, randomized_ttl(std::chrono::seconds(60)));
+                lk.unlock();
+                if (_inflight_registry) _inflight_registry->release(guard.key);
+                return {};
+            }
+            if (_local_members_cache)
+                _local_members_cache->set(mkey, members, randomized_ttl(std::chrono::seconds(8)));
+            lk.unlock();
+            if (_inflight_registry) _inflight_registry->release(guard.key);
+            return members;
+        }
+
+        // L2 miss → RedisMutex for cross-instance stampede
+        RedisMutex warm_mutex(_redis, "warm:members:" + chat_session_id, 5000);
+        if (!warm_mutex.try_lock(std::chrono::milliseconds(100))) {
+            lk.unlock();
+            if (_inflight_registry) _inflight_registry->release(guard.key);
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            return resolve_members(chat_session_id);
+        }
+
+        warm_mutex.unlock();
+        lk.unlock();
+        if (_inflight_registry) _inflight_registry->release(guard.key);
+        return {};
+    }
+
+    void warm_members_cache(const std::string &chat_session_id,
+                            const std::vector<std::string> &members) {
+        std::string mkey = "members:" + chat_session_id;
+        if (members.empty()) {
+            _members_cache->warm_sentinel(chat_session_id);
+            if (_local_members_cache)
+                _local_members_cache->set(mkey, {"__sentinel__"}, randomized_ttl(std::chrono::seconds(60)));
+        } else {
+            _members_cache->warm(chat_session_id, members);
+            if (_local_members_cache)
+                _local_members_cache->set(mkey, members, randomized_ttl(std::chrono::seconds(8)));
+        }
+    }
+
 private:
     std::string _identity_service_name;
     std::string _conversation_service_name;
@@ -345,6 +425,10 @@ private:
     Members::ptr _members_cache;
     RateLimiter::ptr _rate_limiter;
     RedisClient::ptr _redis;
+    LocalCache<std::vector<std::string>>::ptr _local_members_cache;
+    LocalCache<std::string>::ptr _local_user_cache;
+    InflightRegistry::ptr _inflight_registry;
+    std::mutex _dummy_mu_;
 };
 
 class TransmiteServer
@@ -516,6 +600,13 @@ public:
         _members_cache = std::make_shared<Members>(_redis_client);
         _rate_limiter = std::make_shared<RateLimiter>(_redis_client);
     }
+
+    void make_local_cache() {
+        _local_members_cache = std::make_shared<LocalCache<std::vector<std::string>>>(4096);
+        _local_user_cache = std::make_shared<LocalCache<std::string>>(16384);
+        _inflight_registry = std::make_shared<InflightRegistry>();
+    }
+
     /* brief: 构造RPC服务器对象，并添加服务 */
     void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads) {
         if(!_id_generator) {
@@ -546,7 +637,10 @@ public:
                                                                         _seq_gen,
                                                                         _members_cache,
                                                                         _rate_limiter,
-                                                                        _redis_client);
+                                                                        _redis_client,
+                                                                        _local_members_cache,
+                                                                        _local_user_cache,
+                                                                        _inflight_registry);
         int ret = _rpc_server->AddService(transmite_service, brpc::ServiceOwnership::SERVER_OWNS_SERVICE);
         if(ret == -1) {
             LOG_ERROR("添加RPC服务失败!");
@@ -598,6 +692,9 @@ private:
     SeqGen::ptr _seq_gen;
     Members::ptr _members_cache;
     RateLimiter::ptr _rate_limiter;
+    LocalCache<std::vector<std::string>>::ptr _local_members_cache;
+    LocalCache<std::string>::ptr _local_user_cache;
+    InflightRegistry::ptr _inflight_registry;
     std::string _instance_owner;
     std::shared_ptr<etcd::Client> _etcd_client;
     WorkerIdAllocator::ptr _worker_allocator;

--- a/transmite/source/transmite_server.h
+++ b/transmite/source/transmite_server.h
@@ -29,6 +29,7 @@
 #include <butil/logging.h>
 #include <atomic>
 #include <chrono>
+#include <optional>
 #include <thread>
 
 namespace chatnow
@@ -187,7 +188,7 @@ public:
 
         std::vector<std::string> member_id_list;
         for (int retry = 0; retry < 3; ++retry) {
-            member_id_list = resolve_members(chat_ssid);
+            member_id_list = resolve_members(chat_ssid, static_cast<brpc::Controller*>(controller));
             if (!member_id_list.empty()) break;
             if (retry < 2) std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
@@ -315,7 +316,8 @@ public:
         }
     }
 
-    std::vector<std::string> resolve_members(const std::string &chat_session_id) {
+    std::vector<std::string> resolve_members(const std::string &chat_session_id,
+                                               brpc::Controller *caller_cntl = nullptr) {
         std::string mkey = "members:" + chat_session_id;
 
         // ① L1 hit → fast path
@@ -371,7 +373,14 @@ public:
         }
 
         // ⑥ RPC to fetch members (INSIDE the mutex)
-        members = fetch_members_from_conversation_service_(chat_session_id);
+        auto result = fetch_members_from_conversation_service_(chat_session_id, caller_cntl);
+        if (!result.has_value()) {
+            // RPC failed — don't cache, just release and return empty
+            warm_mutex.unlock();
+            release_guard();
+            return {};
+        }
+        members = std::move(*result);
 
         // ⑦ Warm L2 + L1 (INSIDE the mutex)
         if (members.empty()) {
@@ -389,16 +398,20 @@ public:
         return members;
     }
 
-    std::vector<std::string> fetch_members_from_conversation_service_(const std::string &chat_session_id) {
+    std::optional<std::vector<std::string>> fetch_members_from_conversation_service_(
+        const std::string &chat_session_id, brpc::Controller *caller_cntl) {
         auto conv_channel = _mm_channels->choose(_conversation_service_name);
         if (!conv_channel) {
             LOG_ERROR("conversation_service 节点缺失 (warming members for {})", chat_session_id);
-            return {};
+            return std::nullopt;
         }
         ::chatnow::conversation::ConversationService_Stub conv_stub(conv_channel.get());
         ::chatnow::conversation::GetMemberIdsReq member_req;
         ::chatnow::conversation::GetMemberIdsRsp member_rsp;
         brpc::Controller member_cntl;
+        if (caller_cntl) {
+            chatnow::auth::forward_auth_metadata(caller_cntl, &member_cntl);
+        }
         member_req.set_request_id(chat_session_id);
         member_req.set_conversation_id(chat_session_id);
         conv_stub.GetMemberIds(&member_cntl, &member_req, &member_rsp, brpc::DoNothing());
@@ -406,7 +419,7 @@ public:
         if (member_cntl.Failed() || !member_rsp.header().success()) {
             LOG_ERROR("获取群成员失败 (warming): {} {}",
                       member_cntl.ErrorText(), member_rsp.header().error_message());
-            return {};
+            return std::nullopt;
         }
         std::vector<std::string> members;
         for (const auto &m : member_rsp.member_ids()) members.push_back(m);

--- a/transmite/source/transmite_server.h
+++ b/transmite/source/transmite_server.h
@@ -174,9 +174,8 @@ public:
             return err_response(rid, chatnow::error::kSystemUnavailable, "依赖服务暂不可用");
         }
 
-        // 成员列表：L1 → InflightRegistry → L2 Redis → RPC
-        std::vector<std::string> member_id_list = resolve_members(chat_ssid);
-
+        // 成员列表：L1 → InflightRegistry → L2 Redis → RedisMutex → RPC (内置 warm)
+        // 先发起 profile RPC（异步），与成员解析并行
         chatnow::identity::IdentityService_Stub identity_stub(identity_channel.get());
         chatnow::identity::GetProfileReq profile_req;
         chatnow::identity::GetProfileRsp profile_rsp;
@@ -186,31 +185,11 @@ public:
         chatnow::auth::forward_auth_metadata(static_cast<brpc::Controller*>(controller), &profile_cntl);
         identity_stub.GetProfile(&profile_cntl, &profile_req, &profile_rsp, brpc::DoNothing());
 
-        // 成员列表未命中缓存：RPC 拉取 + warm
-        ::chatnow::conversation::GetMemberIdsRsp member_rsp;
-        brpc::Controller member_cntl;
-        if (member_id_list.empty()) {
-            auto conv_channel = _mm_channels->choose(_conversation_service_name);
-            if (!conv_channel) {
-                brpc::Join(profile_cntl.call_id());
-                LOG_ERROR("请求ID: {} - conversation_service 节点缺失", rid);
-                return err_response(rid, chatnow::error::kSystemUnavailable, "依赖服务暂不可用");
-            }
-            ::chatnow::conversation::ConversationService_Stub conv_stub(conv_channel.get());
-            ::chatnow::conversation::GetMemberIdsReq member_req;
-            member_req.set_request_id(rid);
-            member_req.set_conversation_id(chat_ssid);
-            chatnow::auth::forward_auth_metadata(static_cast<brpc::Controller*>(controller), &member_cntl);
-            conv_stub.GetMemberIds(&member_cntl, &member_req, &member_rsp, brpc::DoNothing());
-            brpc::Join(member_cntl.call_id());
-            if (member_cntl.Failed() || !member_rsp.header().success()) {
-                brpc::Join(profile_cntl.call_id());
-                LOG_ERROR("请求ID: {} - 获取群成员失败: {} {}", rid,
-                          member_cntl.ErrorText(), member_rsp.header().error_message());
-                return err_response(rid, chatnow::error::kSystemUnavailable, "获取群成员失败");
-            }
-            for (const auto &m : member_rsp.member_ids()) member_id_list.push_back(m);
-            warm_members_cache(chat_ssid, member_id_list);
+        std::vector<std::string> member_id_list;
+        for (int retry = 0; retry < 3; ++retry) {
+            member_id_list = resolve_members(chat_ssid);
+            if (!member_id_list.empty()) break;
+            if (retry < 2) std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
 
         brpc::Join(profile_cntl.call_id());
@@ -339,66 +318,62 @@ public:
     std::vector<std::string> resolve_members(const std::string &chat_session_id) {
         std::string mkey = "members:" + chat_session_id;
 
+        // ① L1 hit → fast path
         if (_local_members_cache) {
             auto local = _local_members_cache->get(mkey);
             if (local.has_value()) {
-                auto &members = *local;
-                if (members.size() == 1 && members[0] == "__sentinel__")
-                    return {};
-                return members;
-            }
-        }
-
-        auto guard = _inflight_registry ? _inflight_registry->acquire(chat_session_id)
-                                        : InflightRegistry::Guard{};
-        std::shared_ptr<std::mutex> lock_mu = guard.mu;
-        std::unique_lock<std::mutex> lk(lock_mu ? *lock_mu : _dummy_mu_);
-
-        if (_local_members_cache) {
-            auto local = _local_members_cache->get(mkey);
-            if (local.has_value()) {
-                lk.unlock();
-                if (_inflight_registry) _inflight_registry->release(guard.key);
                 auto &members = *local;
                 if (members.size() == 1 && members[0] == "__sentinel__") return {};
                 return members;
             }
         }
 
+        // ② L1 miss → InflightRegistry per-key lock
+        auto guard = _inflight_registry ? _inflight_registry->acquire(chat_session_id)
+                                        : InflightRegistry::Guard{};
+        std::unique_lock<std::mutex> lk(guard.mu ? *guard.mu : _dummy_mu_);
+
+        auto release_guard = [&]() {
+            if (lk.owns_lock()) lk.unlock();
+            if (guard.registry && !guard.key.empty()) guard.registry->release(guard.key);
+        };
+
+        // ③ Double-check L1
+        if (_local_members_cache) {
+            auto local = _local_members_cache->get(mkey);
+            if (local.has_value()) {
+                release_guard();
+                auto &members = *local;
+                if (members.size() == 1 && members[0] == "__sentinel__") return {};
+                return members;
+            }
+        }
+
+        // ④ Double-check L2 Redis
         auto members = _members_cache->list(chat_session_id);
         if (!members.empty()) {
+            release_guard();
             if (members.size() == 1 && members[0] == "__sentinel__") {
                 if (_local_members_cache)
                     _local_members_cache->set(mkey, {"__sentinel__"}, randomized_ttl(std::chrono::seconds(60)));
-                lk.unlock();
-                if (_inflight_registry) _inflight_registry->release(guard.key);
                 return {};
             }
             if (_local_members_cache)
                 _local_members_cache->set(mkey, members, randomized_ttl(std::chrono::seconds(8)));
-            lk.unlock();
-            if (_inflight_registry) _inflight_registry->release(guard.key);
             return members;
         }
 
-        // L2 miss → RedisMutex for cross-instance stampede
+        // ⑤ L2 miss → RedisMutex cross-instance stampede protection
         RedisMutex warm_mutex(_redis, "warm:members:" + chat_session_id, 5000);
         if (!warm_mutex.try_lock(std::chrono::milliseconds(100))) {
-            lk.unlock();
-            if (_inflight_registry) _inflight_registry->release(guard.key);
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            return resolve_members(chat_session_id);
+            release_guard();
+            return {};  // another instance is warming; caller retries (no recursion)
         }
 
-        warm_mutex.unlock();
-        lk.unlock();
-        if (_inflight_registry) _inflight_registry->release(guard.key);
-        return {};
-    }
+        // ⑥ RPC to fetch members (INSIDE the mutex)
+        members = fetch_members_from_conversation_service_(chat_session_id);
 
-    void warm_members_cache(const std::string &chat_session_id,
-                            const std::vector<std::string> &members) {
-        std::string mkey = "members:" + chat_session_id;
+        // ⑦ Warm L2 + L1 (INSIDE the mutex)
         if (members.empty()) {
             _members_cache->warm_sentinel(chat_session_id);
             if (_local_members_cache)
@@ -408,6 +383,34 @@ public:
             if (_local_members_cache)
                 _local_members_cache->set(mkey, members, randomized_ttl(std::chrono::seconds(8)));
         }
+
+        warm_mutex.unlock();
+        release_guard();
+        return members;
+    }
+
+    std::vector<std::string> fetch_members_from_conversation_service_(const std::string &chat_session_id) {
+        auto conv_channel = _mm_channels->choose(_conversation_service_name);
+        if (!conv_channel) {
+            LOG_ERROR("conversation_service 节点缺失 (warming members for {})", chat_session_id);
+            return {};
+        }
+        ::chatnow::conversation::ConversationService_Stub conv_stub(conv_channel.get());
+        ::chatnow::conversation::GetMemberIdsReq member_req;
+        ::chatnow::conversation::GetMemberIdsRsp member_rsp;
+        brpc::Controller member_cntl;
+        member_req.set_request_id(chat_session_id);
+        member_req.set_conversation_id(chat_session_id);
+        conv_stub.GetMemberIds(&member_cntl, &member_req, &member_rsp, brpc::DoNothing());
+        brpc::Join(member_cntl.call_id());
+        if (member_cntl.Failed() || !member_rsp.header().success()) {
+            LOG_ERROR("获取群成员失败 (warming): {} {}",
+                      member_cntl.ErrorText(), member_rsp.header().error_message());
+            return {};
+        }
+        std::vector<std::string> members;
+        for (const auto &m : member_rsp.member_ids()) members.push_back(m);
+        return members;
     }
 
 private:

--- a/transmite/source/transmite_server.h
+++ b/transmite/source/transmite_server.h
@@ -47,7 +47,7 @@ public:
                         const SeqGen::ptr &seq_gen,
                         const Members::ptr &members_cache,
                         const RateLimiter::ptr &rate_limiter,
-                        const std::shared_ptr<sw::redis::Redis> &redis)
+                        const RedisClient::ptr &redis)
                         : _identity_service_name(identity_service_name),
                         _conversation_service_name(conversation_service_name),
                         _message_service_name(message_service_name),
@@ -344,7 +344,7 @@ private:
     SeqGen::ptr _seq_gen;
     Members::ptr _members_cache;
     RateLimiter::ptr _rate_limiter;
-    std::shared_ptr<sw::redis::Redis> _redis;
+    RedisClient::ptr _redis;
 };
 
 class TransmiteServer
@@ -489,14 +489,22 @@ public:
         _publisher = std::make_shared<Publisher>(_mq_client, settings);
         LOG_INFO("Transmite MQ 已就绪: exchange={} (FANOUT, publisher-only)", exchange_name);
     }
-    /* brief: 构造 Redis 客户端 + SeqGen + Members + RateLimiter */
+    void set_redis_seeds(const std::string &seeds) { _redis_seeds = seeds; }
+
+    /* brief: 构造 Redis 客户端 + SeqGen + Members + RateLimiter（双模：单机 / Cluster） */
     void make_redis_object(const std::string &host, uint16_t port, int db,
                           bool keep_alive, int pool_size)
     {
-        _redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
-        _seq_gen = std::make_shared<SeqGen>(_redis);
-        _members_cache = std::make_shared<Members>(_redis);
-        _rate_limiter = std::make_shared<RateLimiter>(_redis);
+        if (!_redis_seeds.empty()) {
+            auto cluster = RedisClusterFactory::create(_redis_seeds, pool_size, keep_alive);
+            _redis_client = std::make_shared<RedisClient>(cluster);
+        } else {
+            auto redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
+            _redis_client = std::make_shared<RedisClient>(redis);
+        }
+        _seq_gen = std::make_shared<SeqGen>(_redis_client);
+        _members_cache = std::make_shared<Members>(_redis_client);
+        _rate_limiter = std::make_shared<RateLimiter>(_redis_client);
     }
     /* brief: 构造RPC服务器对象，并添加服务 */
     void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads) {
@@ -528,7 +536,7 @@ public:
                                                                         _seq_gen,
                                                                         _members_cache,
                                                                         _rate_limiter,
-                                                                        _redis);
+                                                                        _redis_client);
         int ret = _rpc_server->AddService(transmite_service, brpc::ServiceOwnership::SERVER_OWNS_SERVICE);
         if(ret == -1) {
             LOG_ERROR("添加RPC服务失败!");
@@ -575,7 +583,8 @@ private:
     Publisher::ptr _publisher;
     std::shared_ptr<SnowflakeId> _id_generator;
 
-    std::shared_ptr<sw::redis::Redis> _redis;
+    std::string _redis_seeds;
+    RedisClient::ptr _redis_client;
     SeqGen::ptr _seq_gen;
     Members::ptr _members_cache;
     RateLimiter::ptr _rate_limiter;

--- a/transmite/source/transmite_server.h
+++ b/transmite/source/transmite_server.h
@@ -337,7 +337,7 @@ public:
 
         auto release_guard = [&]() {
             if (lk.owns_lock()) lk.unlock();
-            if (guard.registry && !guard.key.empty()) guard.registry->release(guard.key);
+            guard = InflightRegistry::Guard{};
         };
 
         // ③ Double-check L1

--- a/transmite/source/transmite_server.h
+++ b/transmite/source/transmite_server.h
@@ -398,6 +398,20 @@ public:
         return members;
     }
 
+    std::string resolve_user_info(const std::string &uid) {
+        if (!_local_user_cache) return "";
+        std::string ukey = "user:" + uid;
+        auto cached = _local_user_cache->get(ukey);
+        if (cached.has_value()) return *cached;
+        return "";
+    }
+
+    void warm_user_info(const std::string &uid, const std::string &serialized_info) {
+        if (_local_user_cache && !serialized_info.empty())
+            _local_user_cache->set("user:" + uid, serialized_info,
+                                   randomized_ttl(std::chrono::seconds(45)));
+    }
+
     std::optional<std::vector<std::string>> fetch_members_from_conversation_service_(
         const std::string &chat_session_id, brpc::Controller *caller_cntl) {
         auto conv_channel = _mm_channels->choose(_conversation_service_name);

--- a/transmite/source/transmite_server.h
+++ b/transmite/source/transmite_server.h
@@ -355,9 +355,10 @@ public:
     TransmiteServer(const Discovery::ptr &service_discover,
                 const Registry::ptr &reg_client,
                 const std::shared_ptr<brpc::Server> &server,
-                const WorkerIdAllocator::ptr &worker_allocator = nullptr)
+                const WorkerIdAllocator::ptr &worker_allocator = nullptr,
+                const EtcdWorkIdAllocator::ptr &etcd_worker_allocator = nullptr)
         : _service_discover(service_discover), _reg_client(reg_client), _rpc_server(server),
-          _worker_allocator(worker_allocator) {}
+          _worker_allocator(worker_allocator), _etcd_worker_allocator(etcd_worker_allocator) {}
     ~TransmiteServer() {
         _watchdog_running.store(false);
         if(_watchdog_thread.joinable()) _watchdog_thread.join();
@@ -369,11 +370,14 @@ public:
      *    避免 SnowflakeId 用已被别人占据的 worker_id 继续发号产生重号。
      */
     void start() {
-        if(_worker_allocator) {
+        if(_worker_allocator || _etcd_worker_allocator) {
             _watchdog_running.store(true);
             _watchdog_thread = std::thread([this]() {
                 while(_watchdog_running.load()) {
-                    if(_worker_allocator->lease_lost()) {
+                    bool lost = false;
+                    if (_worker_allocator) lost = _worker_allocator->lease_lost();
+                    if (!lost && _etcd_worker_allocator) lost = _etcd_worker_allocator->lease_lost();
+                    if (lost) {
                         // brpc Stop(0) 不会打断 in-flight handler；
                         // 在 worker_id 已被别人占走的状态下，每多发一个雪花 ID 都
                         // 必然撞向对端实例，污染 message 主键唯一约束。
@@ -396,6 +400,7 @@ private:
     Registry::ptr _reg_client;          // 服务注册客户端
     std::shared_ptr<brpc::Server> _rpc_server;
     WorkerIdAllocator::ptr _worker_allocator;
+    EtcdWorkIdAllocator::ptr _etcd_worker_allocator;
     std::atomic<bool> _watchdog_running {false};
     std::thread _watchdog_thread;
 };
@@ -404,18 +409,22 @@ private:
 class TransmiteServerBuilder
 {
 public:
-    /* brief: 构造分布式有序ID生成器（worker_id 优先从 Redis 自动申请，否则用 fallback） */
+    /* brief: 构造分布式有序ID生成器（Cluster 模式用 etcd，单机模式用 Redis，否则 fallback） */
     void make_id_generator_object(uint64_t fallback_worker_id, uint64_t epoch_ms, bool wait_on_clock_backwards)
     {
         try {
             uint64_t worker_id = fallback_worker_id;
-            if(_redis) {
-                std::string owner = _instance_owner.empty() ? std::to_string(getpid()) : _instance_owner;
-                _worker_allocator = std::make_shared<WorkerIdAllocator>(_redis, "transmite", owner);
+            std::string owner = _instance_owner.empty() ? std::to_string(getpid()) : _instance_owner;
+            if (_etcd_client && !_redis_seeds.empty()) {
+                _etcd_worker_allocator = std::make_shared<EtcdWorkIdAllocator>(_etcd_client);
+                int allocated = _etcd_worker_allocator->acquire(owner, static_cast<int>(fallback_worker_id));
+                if (allocated >= 0) worker_id = static_cast<uint64_t>(allocated);
+            } else if (_redis_client) {
+                _worker_allocator = std::make_shared<WorkerIdAllocator>(_redis_client, "transmite", owner);
                 int allocated = _worker_allocator->acquire(static_cast<int>(fallback_worker_id));
-                if(allocated >= 0) worker_id = static_cast<uint64_t>(allocated);
+                if (allocated >= 0) worker_id = static_cast<uint64_t>(allocated);
             } else {
-                LOG_WARN("Redis 未初始化，worker_id 退回配置值 {}", fallback_worker_id);
+                LOG_WARN("Redis / etcd 未初始化，worker_id 退回配置值 {}", fallback_worker_id);
             }
             _id_generator = std::make_shared<SnowflakeId>(worker_id, epoch_ms, wait_on_clock_backwards);
             LOG_INFO("Snowflake worker_id={} epoch_ms={}", worker_id, epoch_ms);
@@ -425,6 +434,7 @@ public:
     }
     /* brief: 设置实例标识（host:pid），用于 worker_id 租约识别 */
     void set_instance_owner(const std::string &owner) { _instance_owner = owner; }
+    void set_etcd_client(std::shared_ptr<etcd::Client> etcd) { _etcd_client = etcd; }
     /* brief: 用于构造服务发现&信道管理客户端对象（含 message_service 用于幂等查询） */
     void make_discovery_object(const std::string &reg_host,
                             const std::string &base_service_name,
@@ -568,7 +578,7 @@ public:
 
         // M4: 把 worker_allocator 传给 server，让 watchdog 线程在 start() 中轮询 lease_lost
         TransmiteServer::ptr server = std::make_shared<TransmiteServer>(
-            _service_discover, _reg_client, _rpc_server, _worker_allocator);
+            _service_discover, _reg_client, _rpc_server, _worker_allocator, _etcd_worker_allocator);
         return server;
     }
 private:
@@ -589,7 +599,9 @@ private:
     Members::ptr _members_cache;
     RateLimiter::ptr _rate_limiter;
     std::string _instance_owner;
+    std::shared_ptr<etcd::Client> _etcd_client;
     WorkerIdAllocator::ptr _worker_allocator;
+    EtcdWorkIdAllocator::ptr _etcd_worker_allocator;
 
     Discovery::ptr _service_discover;   // 服务发现客户端
     Registry::ptr _reg_client;          // 服务注册客户端


### PR DESCRIPTION
## Summary

将缓存基础设施从"单机 Redis + 单层缓存"升级到支持大规模 IM 场景的"Redis Cluster + 多级缓存 + 分层锁"架构。

**Spec:** `docs/superpowers/specs/2026-05-18-cache-infrastructure-redesign.md`

## Changes

### Phase 1: Redis 集群化
- Redis Cluster 6 节点（3M3S）docker-compose 编排
- `RedisClient` 类型擦除适配器：透明转发到 `Redis`（单机）或 `RedisCluster`
- `RedisClusterFactory`：通过种子节点自动发现拓扑
- 8 个服务全部支持 `--redis_seeds` 双模初始化
- 自然 CRC16 分片，不加 hash tag

### Phase 2: 分布式锁分层
- `LeaderElection`：基于 etcd Transaction CAS（Raft 强一致），用于 reaper 选举和 Snowflake worker_id 分配
- `RedisMutex`：基于 SET NX PX + Lua CAS unlock，用于 cache warm 互斥和 SeqGen backfill 协调
- Message PushOutbox/ESOutbox + Push CrossInstanceOutbox reaper 从 Redis Lua CAS 迁移到 etcd LeaderElection
- Snowflake worker_id 分配迁移到 etcd

### Phase 3: L1 本地缓存
- `LocalCache<T>`：线程安全、TTL 自愈的进程内缓存模板
- `InflightRegistry`：per-key 进程内互斥，合并并发穿透请求
- Push 接入 OnlineRoute L1 缓存（TTL 2s，命中率目标 > 90%）
- Transmite 接入 Members + UserInfo L1 缓存（TTL 8s / 45s）
- Push 关停清理 + stale route reaper

### Phase 4: 缓存防护
- `randomized_ttl()`：全部缓存 TTL 加 ±20% 随机偏移（防雪崩）
- Sentinel 空值缓存：不存在的数据缓存 `__sentinel__` 标记（防穿透）
- 缓存型 TTL 全量随机化，数据保持型 TTL（Session/UnackedPush）不随机化

### Phase 5: 监控
- Prometheus 告警规则：Redis Cluster 节点 down、连接池耗尽、LeaderElection 频繁切换、L1 命中率骤降

### Review Fixes (11 commits)
基于 code review 修复了 3 个 CRITICAL + 7 个 IMPORTANT + 3 个 MINOR 问题：
- `RedisMutex::try_lock()` 补 SET NX（跨实例互斥从失效→正确）
- `Transmite::resolve_members()` 重构：锁持有到 RPC+warm 完成 + 移除无限递归
- `docker-compose.yml` depends_on 修正
- `randomized_ttl()` 浮点精度、`InflightRegistry::Guard` RAII、`LeaderElection::stop()` 即时中断
- 死代码清理、构建器一致性、Config 接线完善

## Key Files

| File | Description |
|------|-------------|
| `common/dao/data_redis.hpp` | RedisClient adapter + RedisClusterFactory + Members sentinel |
| `common/utils/local_cache.hpp` | L1 LocalCache<T> template |
| `common/utils/inflight.hpp` | InflightRegistry stampede protection |
| `common/utils/redis_mutex.hpp` | RedisMutex (SET NX PX + Lua CAS unlock) |
| `common/infra/leader_election.hpp` | etcd LeaderElection (Transaction CAS) |
| `common/utils/random_ttl.hpp` | randomized_ttl() utility |
| `push/source/push_server.h` | L1 OnlineRoute cache + shutdown cleanup + stale reaper |
| `transmite/source/transmite_server.h` | L1 Members/UserInfo cache + InflightRegistry + RedisMutex |
| `message/source/message_server.h` | etcd reaper election + SeqGen backfill RedisMutex |
| `docker-compose.yml` | 6-node Redis Cluster |

## Test Plan

- [ ] Redis Cluster: `docker-compose up` → cluster info 确认 3M3S，kill 主节点验证 failover
- [ ] 单机 Redis 兼容：`--redis_seeds=` 空字符串回退单机模式
- [ ] L1 缓存命中率达标（Push OnlineRoute > 90%）
- [ ] Transmite Members 缓存：RPC miss → warm → 后续 L1 hit
- [ ] Push 优雅关停：OnlineRoute 主动清理 + L1 失效
- [ ] Prometheus 告警规则可触发