### PR TITLE
feat(presence): add typing indicator (SendTyping → Push)

### DIFF
--- a/docs/api/openapi-presence.yaml
+++ b/docs/api/openapi-presence.yaml
@@ -1,0 +1,211 @@
+openapi: 3.1.0
+info:
+  title: ChatNow Presence API
+  version: 3.0.0
+  description: |
+    在线状态域。Proto: proto/presence/presence_service.proto
+    Service: chatnow.presence.PresenceService
+
+servers:
+  - url: http://localhost:9000
+    description: Gateway HTTP
+
+security:
+  - bearerAuth: []
+
+paths:
+  /service/presence/get:
+    post:
+      summary: 获取用户在线状态
+      tags: [Presence]
+      x-protobuf: { service: chatnow.presence.PresenceService, rpc: GetPresence, request: GetPresenceReq, response: GetPresenceRsp, file: proto/presence/presence_service.proto }
+      requestBody:
+        required: true
+        content:
+          application/x-protobuf:
+            schema: { $ref: '#/components/schemas/GetPresenceReq' }
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/x-protobuf:
+              schema:
+                allOf:
+                  - $ref: '../openapi-common.yaml#/components/schemas/ResponseHeader'
+                  - $ref: '#/components/schemas/GetPresenceRsp'
+        '4xx': { $ref: '#/components/responses/BusinessError' }
+
+  /service/presence/batch_get:
+    post:
+      summary: 批量获取在线状态
+      tags: [Presence]
+      x-protobuf: { service: chatnow.presence.PresenceService, rpc: BatchGetPresence, request: BatchGetPresenceReq, response: BatchGetPresenceRsp, file: proto/presence/presence_service.proto }
+      requestBody:
+        required: true
+        content:
+          application/x-protobuf:
+            schema: { $ref: '#/components/schemas/BatchGetPresenceReq' }
+      responses:
+        '200':
+          description: 成功，返回 user_id -> Presence 映射
+          content:
+            application/x-protobuf:
+              schema:
+                allOf:
+                  - $ref: '../openapi-common.yaml#/components/schemas/ResponseHeader'
+                  - $ref: '#/components/schemas/BatchGetPresenceRsp'
+        '4xx': { $ref: '#/components/responses/BusinessError' }
+
+  /service/presence/subscribe:
+    post:
+      summary: 订阅在线状态
+      description: subscriber_user_id 从 JWT metadata 提取，无需在 body 中传递。
+      tags: [Presence]
+      x-protobuf: { service: chatnow.presence.PresenceService, rpc: SubscribePresence, request: SubscribeReq, response: SubscribeRsp, file: proto/presence/presence_service.proto }
+      requestBody:
+        required: true
+        content:
+          application/x-protobuf:
+            schema: { $ref: '#/components/schemas/SubscribeReq' }
+      responses:
+        '200': { $ref: '#/components/responses/Success' }
+        '4xx': { $ref: '#/components/responses/BusinessError' }
+
+  /service/presence/unsubscribe:
+    post:
+      summary: 取消订阅在线状态
+      description: subscriber_user_id 从 JWT metadata 提取，无需在 body 中传递。
+      tags: [Presence]
+      x-protobuf: { service: chatnow.presence.PresenceService, rpc: UnsubscribePresence, request: UnsubscribeReq, response: UnsubscribeRsp, file: proto/presence/presence_service.proto }
+      requestBody:
+        required: true
+        content:
+          application/x-protobuf:
+            schema: { $ref: '#/components/schemas/UnsubscribeReq' }
+      responses:
+        '200': { $ref: '#/components/responses/Success' }
+        '4xx': { $ref: '#/components/responses/BusinessError' }
+
+  /service/presence/send_typing:
+    post:
+      summary: 发送输入状态
+      description: user_id 从 JWT metadata 提取。仅 PRIVATE 会话生效，GROUP/CHANNEL 静默忽略。
+      tags: [Presence]
+      x-protobuf: { service: chatnow.presence.PresenceService, rpc: SendTyping, request: TypingReq, response: TypingRsp, file: proto/presence/presence_service.proto }
+      requestBody:
+        required: true
+        content:
+          application/x-protobuf:
+            schema: { $ref: '#/components/schemas/TypingReq' }
+      responses:
+        '200': { $ref: '#/components/responses/Success' }
+        '4xx': { $ref: '#/components/responses/BusinessError' }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  responses:
+    Success:
+      description: 成功（仅 ResponseHeader，无额外数据）
+      content:
+        application/x-protobuf:
+          schema: { $ref: '../openapi-common.yaml#/components/schemas/ResponseHeader' }
+    BusinessError:
+      description: 业务错误（error_code != 0）
+      content:
+        application/x-protobuf:
+          schema: { $ref: '../openapi-common.yaml#/components/schemas/ResponseHeader' }
+
+  schemas:
+    PresenceState:
+      x-protobuf: { message: PresenceState, file: proto/presence/presence_service.proto }
+      type: integer
+      description: 0=UNSPECIFIED, 1=ONLINE, 2=AWAY, 3=BUSY, 4=OFFLINE, 5=INVISIBLE
+
+    DevicePresence:
+      x-protobuf: { message: DevicePresence, file: proto/presence/presence_service.proto }
+      type: object
+      properties:
+        device_id: { type: string }
+        platform: { $ref: '../openapi-common.yaml#/components/schemas/DevicePlatform' }
+        state: { $ref: '#/components/schemas/PresenceState' }
+        last_active_at_ms: { type: integer, format: int64 }
+
+    Presence:
+      x-protobuf: { message: Presence, file: proto/presence/presence_service.proto }
+      type: object
+      properties:
+        user_id: { type: string }
+        aggregated_state: { $ref: '#/components/schemas/PresenceState' }
+        last_active_at_ms: { type: integer, format: int64 }
+        devices:
+          type: array
+          items: { $ref: '#/components/schemas/DevicePresence' }
+
+    GetPresenceReq:
+      x-protobuf: { message: GetPresenceReq, file: proto/presence/presence_service.proto }
+      type: object
+      required: [request_id, user_id]
+      properties:
+        request_id: { type: string }
+        user_id:
+          type: string
+          description: 查询目标用户ID
+
+    GetPresenceRsp:
+      type: object
+      properties:
+        presence: { $ref: '#/components/schemas/Presence' }
+
+    BatchGetPresenceReq:
+      x-protobuf: { message: BatchGetPresenceReq, file: proto/presence/presence_service.proto }
+      type: object
+      required: [request_id, user_ids]
+      properties:
+        request_id: { type: string }
+        user_ids:
+          type: array
+          items: { type: string }
+
+    BatchGetPresenceRsp:
+      type: object
+      properties:
+        presences:
+          type: object
+          additionalProperties: { $ref: '#/components/schemas/Presence' }
+          description: user_id -> Presence 映射
+
+    SubscribeReq:
+      x-protobuf: { message: SubscribeReq, file: proto/presence/presence_service.proto }
+      type: object
+      required: [request_id, subscribe_user_ids]
+      properties:
+        request_id: { type: string }
+        subscribe_user_ids:
+          type: array
+          items: { type: string }
+          description: 要订阅的用户ID列表
+
+    UnsubscribeReq:
+      x-protobuf: { message: UnsubscribeReq, file: proto/presence/presence_service.proto }
+      type: object
+      required: [request_id, unsubscribe_user_ids]
+      properties:
+        request_id: { type: string }
+        unsubscribe_user_ids:
+          type: array
+          items: { type: string }
+          description: 要取消订阅的用户ID列表
+
+    TypingReq:
+      x-protobuf: { message: TypingReq, file: proto/presence/presence_service.proto }
+      type: object
+      required: [request_id, conversation_id, is_typing]
+      properties:
+        request_id: { type: string }
+        conversation_id: { type: string }
+        is_typing: { type: boolean }

--- a/docs/superpowers/plans/2026-05-21-typing-indicator.md
+++ b/docs/superpowers/plans/2026-05-21-typing-indicator.md
@@ -1,0 +1,325 @@
+# Typing 通知 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 完成"对方正在输入..."服务端链路，使 PRIVATE 会话中 Client A 调用 SendTyping 后 Client B 通过 WebSocket 收到 TYPING_NOTIFY。
+
+**Architecture:** 改造 Presence 服务的 SendTyping RPC：在现有 Redis 写入后新增推送逻辑——解析 PRIVATE 会话 ID 提取对方 uid，构造 NotifyTyping，通过 PushService::PushToUser 下发。Gateway 新增路由，OpenAPI 补充文档。Push 服务、Proto 均无需改动。
+
+**Tech Stack:** C++ (brpc), Redis (sw::redis++), Protocol Buffers, YAML (OpenAPI 3.1)
+
+**Spec:** `docs/superpowers/specs/2026-05-21-typing-indicator-design.md`
+
+---
+
+### Task 1: Presence 服务 SendTyping 增加推送下发逻辑
+
+**Files:**
+- Modify: `presence/source/presence_server.h:275-310`
+
+- [ ] **Step 1: 改造 SendTyping 方法**
+
+将 `SendTyping` 方法改为以下内容（替换现有 275-310 行）：
+
+```cpp
+void SendTyping(::google::protobuf::RpcController* base_cntl,
+                const TypingReq* req, TypingRsp* rsp,
+                ::google::protobuf::Closure* done) override
+{
+    brpc::ClosureGuard done_guard(done);
+    auto* cntl = static_cast<brpc::Controller*>(base_cntl);
+    try {
+        auto auth = ::chatnow::auth::extract_auth(cntl);
+        auto* h = rsp->mutable_header();
+        h->set_success(true);
+        h->set_error_code(::chatnow::error::kOK);
+        h->set_request_id(req->request_id());
+
+        const auto& conv_id = req->conversation_id();
+
+        if (req->is_typing()) {
+            auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _redis->sadd("im:presence:typing:" + conv_id,
+                         auth.user_id + ":" + std::to_string(now_ms));
+            _redis->expire("im:presence:typing:" + conv_id, std::chrono::seconds(5));
+        } else {
+            std::vector<std::string> members;
+            _redis->smembers("im:presence:typing:" + conv_id,
+                             std::inserter(members, members.end()));
+            for (const auto& m : members) {
+                if (m.find(auth.user_id + ":") == 0) {
+                    _redis->srem("im:presence:typing:" + conv_id, m);
+                }
+            }
+        }
+
+        // 仅 PRIVATE 会话下发 typing 通知
+        if (conv_id.size() < 2 || conv_id[0] != 'p' || conv_id[1] != '_') return;
+
+        auto pos = conv_id.find('_', 2);  // 第二个下划线，分隔 lo 和 hi
+        if (pos == std::string::npos) return;
+
+        std::string lo = conv_id.substr(2, pos - 2);
+        std::string hi = conv_id.substr(pos + 1);
+        std::string target = (lo == auth.user_id) ? hi : lo;
+
+        auto channel = _channels->choose(_push_service_name);
+        if (!channel) return;
+
+        ::chatnow::push::NotifyMessage notify;
+        notify.set_notify_type(::chatnow::push::NotifyType::TYPING_NOTIFY);
+        auto* tn = notify.mutable_typing();
+        tn->set_user_id(auth.user_id);
+        tn->set_conversation_id(conv_id);
+        tn->set_is_typing(req->is_typing());
+
+        auto* closure = new SelfDeleteRpcClosure<::chatnow::push::PushToUserReq,
+                                                  ::chatnow::push::PushToUserRsp>();
+        closure->req.set_user_id(target);
+        closure->req.mutable_notify()->CopyFrom(notify);
+
+        ::chatnow::push::PushService_Stub stub(channel.get());
+        stub.PushToUser(&closure->cntl, &closure->req, &closure->rsp, closure);
+    } catch (const ServiceError& e) {
+        rsp->mutable_header()->set_success(false);
+        rsp->mutable_header()->set_error_code(e.code());
+        rsp->mutable_header()->set_error_message(e.message());
+        rsp->mutable_header()->set_request_id(req->request_id());
+    }
+}
+```
+
+注意变更：
+- `expire` 从 10s 改为 5s
+- 从 `notify_subscribers` 模式（include guard、日志级别）保持一致
+- 仅 `p_` 前缀的 PRIVATE 会话 ID 下发通知
+- 使用 `SelfDeleteRpcClosure` 做 fire-and-forget RPC 推送
+
+- [ ] **Step 2: 编译验证**
+
+```bash
+cd build && cmake --build . --target presence_server 2>&1 | head -30
+```
+
+Expected: 编译通过，无错误。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add presence/source/presence_server.h
+git commit -m "feat(presence): add typing notify push to SendTyping"
+```
+
+---
+
+### Task 2: Gateway 注册 SendTyping 路由
+
+**Files:**
+- Modify: `gateway/source/gateway_server.h:425`（在 UnsubscribePresence 路由之后插入）
+
+- [ ] **Step 1: 添加路由**
+
+在 `gateway/source/gateway_server.h` 第 425 行（`UnsubscribePresence` 路由之后）插入：
+
+```cpp
+    route<pres::PresenceService_Stub, pres::TypingReq, pres::TypingRsp>(
+        "/service/presence/send_typing", _presence_svc, GatewayAuth::JWT_REQUIRED,
+        &pres::PresenceService_Stub::SendTyping);
+```
+
+注意：需要确认 `pres::TypingReq` 和 `pres::TypingRsp` 在 proto 生成的 `presence_service.pb.h` 中已定义（它们已在 proto 文件中定义，编译时生成）。
+
+- [ ] **Step 2: 编译验证**
+
+```bash
+cd build && cmake --build . --target gateway_server 2>&1 | head -30
+```
+
+Expected: 编译通过，无错误。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gateway/source/gateway_server.h
+git commit -m "feat(gateway): add SendTyping route for presence service"
+```
+
+---
+
+### Task 3: OpenAPI 文档更新
+
+**Files:**
+- Modify: `docs/api/openapi-presence.yaml`
+
+- [ ] **Step 1: 添加 SendTyping 路径**
+
+在 `paths` 下 `/service/presence/unsubscribe:` 之后新增：
+
+```yaml
+  /service/presence/send_typing:
+    post:
+      summary: 发送输入状态
+      description: user_id 从 JWT metadata 提取。仅 PRIVATE 会话生效，GROUP/CHANNEL 静默忽略。
+      tags: [Presence]
+      x-protobuf: { service: chatnow.presence.PresenceService, rpc: SendTyping, request: TypingReq, response: TypingRsp, file: proto/presence/presence_service.proto }
+      requestBody:
+        required: true
+        content:
+          application/x-protobuf:
+            schema: { $ref: '#/components/schemas/TypingReq' }
+      responses:
+        '200': { $ref: '#/components/responses/Success' }
+        '4xx': { $ref: '#/components/responses/BusinessError' }
+```
+
+- [ ] **Step 2: 添加 TypingReq Schema**
+
+在 `components/schemas` 部分的末尾（`UnsubscribeReq` 之后）新增：
+
+```yaml
+    TypingReq:
+      x-protobuf: { message: TypingReq, file: proto/presence/presence_service.proto }
+      type: object
+      required: [request_id, conversation_id, is_typing]
+      properties:
+        request_id: { type: string }
+        conversation_id: { type: string }
+        is_typing: { type: boolean }
+```
+
+- [ ] **Step 3: 验证 YAML 合法性**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('docs/api/openapi-presence.yaml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/api/openapi-presence.yaml
+git commit -m "docs(api): add SendTyping endpoint to openapi-presence"
+```
+
+---
+
+### Task 4: 功能验证
+
+**Files:**
+- No file changes, manual verification only
+
+- [ ] **Step 1: 确认编译通过**
+
+```bash
+cd build && cmake --build . --target presence_server gateway_server 2>&1 | tail -10
+```
+
+Expected: 两个 target 均编译成功。
+
+- [ ] **Step 2: 路由注册验证**
+
+```bash
+grep -A2 "send_typing" gateway/source/gateway_server.h
+```
+
+Expected: 显示完整 route 调用，路径为 `/service/presence/send_typing`。
+
+- [ ] **Step 3: 伪代码走查**
+
+在 `presence/source/presence_server.h` 的 SendTyping 中确认：
+- PRIVATE 会话 ID `p_uid1_uid2` → 正确解析出 lo/hi 并选择非 caller 的 target
+- GROUP 会话 ID（非 `p_` 前缀）→ 仅写 Redis，不调用 PushToUser
+- `expire` 参数为 `std::chrono::seconds(5)` 而非 10
+
+- [ ] **Step 4: Commit（如有修正）**
+
+```bash
+git status
+# 如有修正，commit
+```
+
+---
+
+### Task 5: 编写功能测试（Go func test）
+
+**Files:**
+- Modify: `tests/func/presence_test.go`
+
+- [ ] **Step 1: 添加 SendTyping PRIVATE 会话测试**
+
+在 `tests/func/presence_test.go` 末尾新增：
+
+```go
+func TestSendTyping_PrivateChat_True(t *testing.T) {
+	a, _, _ := fixture.RegisterAndLogin(t, HTTP)
+	b, _, _ := fixture.RegisterAndLogin(t, HTTP)
+
+	cid := "p_" + a.UserID + "_" + b.UserID
+	if a.UserID > b.UserID {
+		cid = "p_" + b.UserID + "_" + a.UserID
+	}
+
+	req := &presence.TypingReq{
+		RequestId:      client.NewRequestID(),
+		ConversationId: cid,
+		IsTyping:       true,
+	}
+	rsp := &presence.TypingRsp{}
+	err := a.DoAuth("/service/presence/send_typing", req, rsp)
+	require.NoError(t, err)
+	assert.True(t, rsp.Header.Success)
+}
+
+func TestSendTyping_PrivateChat_False(t *testing.T) {
+	a, _, _ := fixture.RegisterAndLogin(t, HTTP)
+	b, _, _ := fixture.RegisterAndLogin(t, HTTP)
+
+	cid := "p_" + a.UserID + "_" + b.UserID
+	if a.UserID > b.UserID {
+		cid = "p_" + b.UserID + "_" + a.UserID
+	}
+
+	req := &presence.TypingReq{
+		RequestId:      client.NewRequestID(),
+		ConversationId: cid,
+		IsTyping:       false,
+	}
+	rsp := &presence.TypingRsp{}
+	err := a.DoAuth("/service/presence/send_typing", req, rsp)
+	require.NoError(t, err)
+	assert.True(t, rsp.Header.Success)
+}
+
+func TestSendTyping_GroupChat_NoOp(t *testing.T) {
+	a, _, _ := fixture.RegisterAndLogin(t, HTTP)
+
+	req := &presence.TypingReq{
+		RequestId:      client.NewRequestID(),
+		ConversationId: "g_some_group_id",
+		IsTyping:       true,
+	}
+	rsp := &presence.TypingRsp{}
+	err := a.DoAuth("/service/presence/send_typing", req, rsp)
+	require.NoError(t, err)
+	assert.True(t, rsp.Header.Success)
+}
+```
+
+注意：PRIVATE 会话 ID 需要符合 `p_{lo}_{hi}` 格式（`a.UserID < b.UserID` 时 lo=a, hi=b）。
+
+- [ ] **Step 2: 运行测试**
+
+```bash
+cd tests && go test -tags=func -run "TestSendTyping" -v -count=1 ./... 2>&1
+```
+
+Expected: 3 个测试 PASS。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/func/presence_test.go
+git commit -m "test(presence): add SendTyping functional tests"
+```

--- a/docs/superpowers/specs/2026-05-21-typing-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-21-typing-indicator-design.md
@@ -83,7 +83,43 @@ route<pres::PresenceService_Stub, pres::TypingReq, pres::TypingRsp>(
     &pres::PresenceService_Stub::SendTyping);
 ```
 
-### 3. 无需改动
+### 3. OpenAPI 文档更新
+
+文件：`docs/api/openapi-presence.yaml`
+
+在 `paths` 下新增 `/service/presence/send_typing`，在 `components/schemas` 下新增 `TypingReq`：
+
+```yaml
+  /service/presence/send_typing:
+    post:
+      summary: 发送输入状态
+      description: user_id 从 JWT metadata 提取。仅 PRIVATE 会话生效，GROUP/CHANNEL 静默忽略。
+      tags: [Presence]
+      x-protobuf: { service: chatnow.presence.PresenceService, rpc: SendTyping, request: TypingReq, response: TypingRsp, file: proto/presence/presence_service.proto }
+      requestBody:
+        required: true
+        content:
+          application/x-protobuf:
+            schema: { $ref: '#/components/schemas/TypingReq' }
+      responses:
+        '200': { $ref: '#/components/responses/Success' }
+        '4xx': { $ref: '#/components/responses/BusinessError' }
+```
+
+Schemas 新增：
+
+```yaml
+    TypingReq:
+      x-protobuf: { message: TypingReq, file: proto/presence/presence_service.proto }
+      type: object
+      required: [request_id, conversation_id, is_typing]
+      properties:
+        request_id: { type: string }
+        conversation_id: { type: string }
+        is_typing: { type: boolean }
+```
+
+### 4. 无需改动
 
 - **Push 服务**：`PushToUser` 已存在；`NotifyTyping` 包含在 `NotifyMessage` oneof 中，`PushToUser` 透传任意 `NotifyMessage`，无需特殊处理
 - **Proto**：`TypingReq`、`TypingRsp`、`NotifyTyping`、`TYPING_NOTIFY` 均已定义
@@ -108,3 +144,4 @@ route<pres::PresenceService_Stub, pres::TypingReq, pres::TypingRsp>(
 
 - Presence `SendTyping` 单测：验证 PRIVATE 会话写入 Redis + 调用 PushToUser；GROUP 会话仅写 Redis 不推送
 - Gateway 路由测试：验证 `/service/presence/send_typing` 正确转发
+- OpenAPI 文档：验证 `openapi-presence.yaml` 包含 SendTyping 端点及 TypingReq schema

--- a/docs/superpowers/specs/2026-05-21-typing-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-21-typing-indicator-design.md
@@ -1,0 +1,110 @@
+# Typing 通知 — 服务端设计
+
+## 概述
+
+完成"对方正在输入..."功能的服务端链路，使 Client A 调用 `SendTyping` 后，Client B 通过 WebSocket 收到 `TYPING_NOTIFY`。
+
+## 范围
+
+- **仅限 PRIVATE（单聊）会话**。GROUP/CHANNEL 不处理。
+- **仅服务端**，不涉及客户端 UI 逻辑。
+
+## 现有基础
+
+| 组件 | 状态 |
+|---|---|
+| Proto: `TypingReq`, `TypingRsp`, `NotifyTyping`, `TYPING_NOTIFY` | 已定义 |
+| Presence: `SendTyping` 写 Redis `im:presence:typing:{conv_id}` | 已实现 |
+| Push: `PushToUser` WebSocket 下发 | 已实现 |
+| Push: `NotifyTyping` 处理逻辑 | **未实现** |
+| Gateway: `/service/presence/send_typing` 路由 | **未实现** |
+
+## 数据流
+
+```
+Client A                     Presence                    Push                    Client B
+   │                            │                         │                        │
+   │──POST /send_typing────────►│                         │                        │
+   │  {conv_id, is_typing=true} │                         │                        │
+   │                            │──SADD + EXPIRE 5s───────│                        │
+   │                            │                         │                        │
+   │                            │──PushToUser(B, Notify──►│                        │
+   │                            │   Typing {A, conv,      │──WS binary frame──────►│
+   │                            │    is_typing=true})     │                        │
+```
+
+## 改动点
+
+### 1. Presence 服务 `SendTyping` 改造
+
+文件：`presence/source/presence_server.h`
+
+在现有 Redis 写入之后新增推送逻辑：
+
+1. 解析 `conversation_id`：PRIVATE 会话 ID 格式为 `p_{lo_uid}_{hi_uid}`（见 `private_id_of_`），提取两个 uid
+2. 找到非 caller 的 uid 作为 target
+3. 构造 `NotifyTyping { user_id=caller, conversation_id, is_typing }`
+4. 通过 `PushService_Stub::PushToUser` 推送
+5. Redis TTL 从 10s 改为 5s
+6. 非 `p_` 前缀的 conversation_id 静默跳过（GROUP/CHANNEL）
+
+处理逻辑：
+
+<pre>
+SendTyping(conv_id, is_typing):
+  # 现有：写/删 Redis
+  if is_typing:
+    SADD im:presence:typing:{conv_id} "{uid}:{now_ms}"
+    EXPIRE im:presence:typing:{conv_id} 5s
+  else:
+    SREM im:presence:typing:{conv_id} "{uid}:*"
+
+  # 新增：仅 PRIVATE 会话下发
+  if not conv_id.starts_with("p_"):
+    return  # GROUP/CHANNEL，不处理
+
+  # 解析 p_{lo}_{hi} 找出对方 uid
+  target = (lo == caller) ? hi : lo
+
+  # 构造并推送
+  notify = NotifyMessage { type=TYPING_NOTIFY, typing={ caller, conv_id, is_typing } }
+  stub.PushToUser(target_uid=target, notify)
+</pre>
+
+### 2. Gateway 路由注册
+
+文件：`gateway/source/gateway_server.h`
+
+沿用现有 Presence 路由模式，新增：
+
+```cpp
+route<pres::PresenceService_Stub, pres::TypingReq, pres::TypingRsp>(
+    "/service/presence/send_typing", _presence_svc, GatewayAuth::JWT_REQUIRED,
+    &pres::PresenceService_Stub::SendTyping);
+```
+
+### 3. 无需改动
+
+- **Push 服务**：`PushToUser` 已存在；`NotifyTyping` 包含在 `NotifyMessage` oneof 中，`PushToUser` 透传任意 `NotifyMessage`，无需特殊处理
+- **Proto**：`TypingReq`、`TypingRsp`、`NotifyTyping`、`TYPING_NOTIFY` 均已定义
+- **Redis key**：`im:presence:typing:{conv_id}` 已存在
+
+## 协议行为
+
+- `is_typing=true`：开始输入，对端显示"正在输入..."，5 秒内无刷新则自动消失
+- `is_typing=false`：停止输入（用户发消息或主动取消），对端立即消除
+- 客户端需每 3-5 秒刷新 `is_typing=true` 以保持显示
+
+## 边界情况
+
+| 场景 | 处理 |
+|---|---|
+| GROUP/CHANNEL 会话 | conversation_id 非 `p_` 前缀，静默跳过 |
+| 对方不在线 | `PushToUser` 返回 `online_device_count=0`，正常 |
+| 客户端崩溃（未发送 is_typing=false） | Redis TTL 5s 后自动清理，对端超时自消 |
+| 发消息后继续输入 | 消息到达 → 对端消除 typing → 新 typing 到达 → 对端重新显示 |
+
+## 测试
+
+- Presence `SendTyping` 单测：验证 PRIVATE 会话写入 Redis + 调用 PushToUser；GROUP 会话仅写 Redis 不推送
+- Gateway 路由测试：验证 `/service/presence/send_typing` 正确转发

--- a/docs/superpowers/specs/2026-05-21-typing-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-21-typing-indicator-design.md
@@ -16,7 +16,7 @@
 | Proto: `TypingReq`, `TypingRsp`, `NotifyTyping`, `TYPING_NOTIFY` | 已定义 |
 | Presence: `SendTyping` 写 Redis `im:presence:typing:{conv_id}` | 已实现 |
 | Push: `PushToUser` WebSocket 下发 | 已实现 |
-| Push: `NotifyTyping` 处理逻辑 | **未实现** |
+| Push: `PushToUser` 透传任意 NotifyMessage | 已实现，无需改动 |
 | Gateway: `/service/presence/send_typing` 路由 | **未实现** |
 
 ## 数据流

--- a/gateway/source/gateway_server.h
+++ b/gateway/source/gateway_server.h
@@ -423,6 +423,9 @@ inline void GatewayServer::register_routes() {
     route<pres::PresenceService_Stub, pres::UnsubscribeReq, pres::UnsubscribeRsp>(
         "/service/presence/unsubscribe", _presence_svc, GatewayAuth::JWT_REQUIRED,
         &pres::PresenceService_Stub::UnsubscribePresence);
+    route<pres::PresenceService_Stub, pres::TypingReq, pres::TypingRsp>(
+        "/service/presence/send_typing", _presence_svc, GatewayAuth::JWT_REQUIRED,
+        &pres::PresenceService_Stub::SendTyping);
 
     // ====== 注册 HTTP handler ======
     for (auto& route : _routes) {

--- a/presence/source/presence_server.h
+++ b/presence/source/presence_server.h
@@ -285,22 +285,52 @@ public:
             h->set_error_code(::chatnow::error::kOK);
             h->set_request_id(req->request_id());
 
+            const auto& conv_id = req->conversation_id();
+
             if (req->is_typing()) {
                 auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now().time_since_epoch()).count();
-                _redis->sadd("im:presence:typing:" + req->conversation_id(),
+                _redis->sadd("im:presence:typing:" + conv_id,
                              auth.user_id + ":" + std::to_string(now_ms));
-                _redis->expire("im:presence:typing:" + req->conversation_id(), std::chrono::seconds(10));
+                _redis->expire("im:presence:typing:" + conv_id, std::chrono::seconds(5));
             } else {
                 std::vector<std::string> members;
-                _redis->smembers("im:presence:typing:" + req->conversation_id(),
+                _redis->smembers("im:presence:typing:" + conv_id,
                                  std::inserter(members, members.end()));
                 for (const auto& m : members) {
                     if (m.find(auth.user_id + ":") == 0) {
-                        _redis->srem("im:presence:typing:" + req->conversation_id(), m);
+                        _redis->srem("im:presence:typing:" + conv_id, m);
                     }
                 }
             }
+
+            // 仅 PRIVATE 会话下发 typing 通知
+            if (conv_id.size() < 2 || conv_id[0] != 'p' || conv_id[1] != '_') return;
+
+            auto pos = conv_id.find('_', 2);  // 第二个下划线，分隔 lo 和 hi
+            if (pos == std::string::npos) return;
+
+            std::string lo = conv_id.substr(2, pos - 2);
+            std::string hi = conv_id.substr(pos + 1);
+            std::string target = (lo == auth.user_id) ? hi : lo;
+
+            auto channel = _channels->choose(_push_service_name);
+            if (!channel) return;
+
+            ::chatnow::push::NotifyMessage notify;
+            notify.set_notify_type(::chatnow::push::NotifyType::TYPING_NOTIFY);
+            auto* tn = notify.mutable_typing();
+            tn->set_user_id(auth.user_id);
+            tn->set_conversation_id(conv_id);
+            tn->set_is_typing(req->is_typing());
+
+            auto* closure = new SelfDeleteRpcClosure<::chatnow::push::PushToUserReq,
+                                                      ::chatnow::push::PushToUserRsp>();
+            closure->req.set_user_id(target);
+            closure->req.mutable_notify()->CopyFrom(notify);
+
+            ::chatnow::push::PushService_Stub stub(channel.get());
+            stub.PushToUser(&closure->cntl, &closure->req, &closure->rsp, closure);
         } catch (const ServiceError& e) {
             rsp->mutable_header()->set_success(false);
             rsp->mutable_header()->set_error_code(e.code());

--- a/presence/source/presence_server.h
+++ b/presence/source/presence_server.h
@@ -312,6 +312,7 @@ public:
 
             std::string lo = conv_id.substr(2, pos - 2);
             std::string hi = conv_id.substr(pos + 1);
+            if (lo != auth.user_id && hi != auth.user_id) return;
             std::string target = (lo == auth.user_id) ? hi : lo;
 
             auto channel = _channels->choose(_push_service_name);

--- a/presence/source/presence_server.h
+++ b/presence/source/presence_server.h
@@ -316,7 +316,10 @@ public:
             std::string target = (lo == auth.user_id) ? hi : lo;
 
             auto channel = _channels->choose(_push_service_name);
-            if (!channel) return;
+            if (!channel) {
+                LOG_WARN("SendTyping 推送失败: Push 不可用 conv_id={}", conv_id);
+                return;
+            }
 
             ::chatnow::push::NotifyMessage notify;
             notify.set_notify_type(::chatnow::push::NotifyType::TYPING_NOTIFY);

--- a/tests/func/presence_test.go
+++ b/tests/func/presence_test.go
@@ -60,3 +60,57 @@ func TestUnsubscribePresence_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, rsp.Header.Success)
 }
+
+func TestSendTyping_PrivateChat_True(t *testing.T) {
+	a, _, _ := fixture.RegisterAndLogin(t, HTTP)
+	b, _, _ := fixture.RegisterAndLogin(t, HTTP)
+
+	cid := "p_" + a.UserID + "_" + b.UserID
+	if a.UserID > b.UserID {
+		cid = "p_" + b.UserID + "_" + a.UserID
+	}
+
+	req := &presence.TypingReq{
+		RequestId:      client.NewRequestID(),
+		ConversationId: cid,
+		IsTyping:       true,
+	}
+	rsp := &presence.TypingRsp{}
+	err := a.DoAuth("/service/presence/send_typing", req, rsp)
+	require.NoError(t, err)
+	assert.True(t, rsp.Header.Success)
+}
+
+func TestSendTyping_PrivateChat_False(t *testing.T) {
+	a, _, _ := fixture.RegisterAndLogin(t, HTTP)
+	b, _, _ := fixture.RegisterAndLogin(t, HTTP)
+
+	cid := "p_" + a.UserID + "_" + b.UserID
+	if a.UserID > b.UserID {
+		cid = "p_" + b.UserID + "_" + a.UserID
+	}
+
+	req := &presence.TypingReq{
+		RequestId:      client.NewRequestID(),
+		ConversationId: cid,
+		IsTyping:       false,
+	}
+	rsp := &presence.TypingRsp{}
+	err := a.DoAuth("/service/presence/send_typing", req, rsp)
+	require.NoError(t, err)
+	assert.True(t, rsp.Header.Success)
+}
+
+func TestSendTyping_GroupChat_NoOp(t *testing.T) {
+	a, _, _ := fixture.RegisterAndLogin(t, HTTP)
+
+	req := &presence.TypingReq{
+		RequestId:      client.NewRequestID(),
+		ConversationId: "g_some_group_id",
+		IsTyping:       true,
+	}
+	rsp := &presence.TypingRsp{}
+	err := a.DoAuth("/service/presence/send_typing", req, rsp)
+	require.NoError(t, err)
+	assert.True(t, rsp.Header.Success)
+}

--- a/tests/func/presence_test.go
+++ b/tests/func/presence_test.go
@@ -101,7 +101,7 @@ func TestSendTyping_PrivateChat_False(t *testing.T) {
 	assert.True(t, rsp.Header.Success)
 }
 
-func TestSendTyping_GroupChat_NoOp(t *testing.T) {
+func TestSendTyping_GroupChat_Success(t *testing.T) {
 	a, _, _ := fixture.RegisterAndLogin(t, HTTP)
 
 	req := &presence.TypingReq{


### PR DESCRIPTION
## Summary
- Presence SendTyping 改造：Redis 写入后解析 PRIVATE 会话 ID，构造 TYPING_NOTIFY 并通过 PushService::PushToUser 下发
- Gateway 注册 /service/presence/send_typing 路由
- OpenAPI 文档补充 SendTyping 端点
- Go 功能测试

## Changed Files
- `presence/source/presence_server.h` — SendTyping 推送逻辑
- `gateway/source/gateway_server.h` — 路由注册
- `docs/api/openapi-presence.yaml` — API 文档
- `tests/func/presence_test.go` — 3 个功能测试

## Test Plan
- [ ] Go func tests pass
- [ ] SendTyping in private chat pushes TYPING_NOTIFY to peer
- [ ] SendTyping in group chat writes Redis only, no push