### PR TITLE
feat: ES-MySQL consistency — retry + Redis Outbox fallback for Conversation & Identity

### DIFF
--- a/common/dao/data_redis.hpp
+++ b/common/dao/data_redis.hpp
@@ -835,29 +835,31 @@ class ESOutbox
 {
 public:
     using ptr = std::shared_ptr<ESOutbox>;
-    ESOutbox(const RedisClient::ptr &c) : _c(c) {}
+    ESOutbox(const RedisClient::ptr &c, const std::string &key)
+        : _c(c), _key(key) {}
+    ESOutbox(const RedisClient::ptr &c) : ESOutbox(c, "im:es:outbox") {}
 
     void enqueue(const std::string &payload, long long score_ts) {
-        try { _c->zadd(kEsOutboxKey, payload, static_cast<double>(score_ts)); }
+        try { _c->zadd(_key, payload, static_cast<double>(score_ts)); }
         catch(std::exception &e) { LOG_ERROR("ESOutbox.enqueue 失败: {}", e.what()); }
     }
 
     std::vector<std::string> peek(long limit = 50) {
         std::vector<std::string> res;
         try {
-            _c->zrange(kEsOutboxKey, 0, limit - 1, std::back_inserter(res));
+            _c->zrange(_key, 0, limit - 1, std::back_inserter(res));
         } catch(std::exception &e) { LOG_ERROR("ESOutbox.peek 失败: {}", e.what()); }
         return res;
     }
 
     void remove(const std::string &payload) {
-        try { _c->zrem(kEsOutboxKey, payload); }
+        try { _c->zrem(_key, payload); }
         catch(std::exception &e) { LOG_ERROR("ESOutbox.remove 失败: {}", e.what()); }
     }
 
 private:
     RedisClient::ptr _c;
-    static constexpr const char *kEsOutboxKey     = "im:es:outbox";
+    std::string _key;
 };
 
 // =============================================================================

--- a/common/infra/metrics.hpp
+++ b/common/infra/metrics.hpp
@@ -8,5 +8,6 @@ namespace chatnow::metrics {
 inline bvar::Adder<long> g_degraded_identity_total;
 inline bvar::Adder<long> g_degraded_message_total;
 inline bvar::Adder<long> g_degraded_es_write_total;
+inline bvar::Adder<long> g_es_retry_total;
 
 }  // namespace chatnow::metrics

--- a/conversation/source/conversation_server.h
+++ b/conversation/source/conversation_server.h
@@ -73,6 +73,30 @@ public:
 
     ~ConversationServiceImpl() override = default;
 
+    void start_es_outbox_reaper() {
+        _es_reaper_running = std::make_shared<std::atomic<bool>>(true);
+        _es_reaper_thread = std::make_shared<std::thread>([this]() {
+            while (*_es_reaper_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                try {
+                    auto items = _es_outbox->peek(50);
+                    for (const auto &item : items) {
+                        if (replay_es_write_(item))
+                            _es_outbox->remove(item);
+                    }
+                } catch (std::exception &e) {
+                    LOG_WARN("ESOutbox reaper 异常: {}", e.what());
+                }
+            }
+        });
+    }
+
+    void stop_es_outbox_reaper() {
+        if (_es_reaper_running) *_es_reaper_running = false;
+        if (_es_reaper_thread && _es_reaper_thread->joinable())
+            _es_reaper_thread->join();
+    }
+
     // —— 18 个 RPC 占位实现（T10–T14 逐步替换） ——
     // T10 已替换：ListConversations / GetConversation / ListMembers /
     //              SearchConversations / GetMemberIds
@@ -964,6 +988,8 @@ private:
     ConversationServiceConfig     _cfg;
     ESOutbox::ptr                          _es_outbox;
     ESConversation::ptr                    _es_conv_reaper;
+    std::shared_ptr<std::atomic<bool>>   _es_reaper_running;
+    std::shared_ptr<std::thread>         _es_reaper_thread;
 
     /* brief: 解析 Outbox payload 并重放 ES 写入（Reaper 线程调用，使用独立 _es_conv_reaper） */
     bool replay_es_write_(const std::string &payload) {
@@ -1044,20 +1070,28 @@ public:
     ConversationServer(const Discovery::ptr &service_discover,
                        const Registry::ptr &reg_client,
                        const std::shared_ptr<odb::core::database> &mysql_client,
-                       const std::shared_ptr<brpc::Server> &server)
+                       const std::shared_ptr<brpc::Server> &server,
+                       ConversationServiceImpl *impl)
         : _service_discover(service_discover),
           _reg_client(reg_client),
           _mysql_client(mysql_client),
-          _rpc_server(server) {}
+          _rpc_server(server),
+          _impl(impl) {}
 
-    ~ConversationServer() = default;
-    void start() { _rpc_server->RunUntilAskedToQuit(); }
+    ~ConversationServer() {
+        if (_impl) _impl->stop_es_outbox_reaper();
+    }
+    void start() {
+        if (_impl) _impl->start_es_outbox_reaper();
+        _rpc_server->RunUntilAskedToQuit();
+    }
 
 private:
     Discovery::ptr _service_discover;
     Registry::ptr  _reg_client;
     std::shared_ptr<odb::core::database> _mysql_client;
     std::shared_ptr<brpc::Server>        _rpc_server;
+    ConversationServiceImpl*             _impl = nullptr;
 };
 
 class ConversationServerBuilder
@@ -1065,6 +1099,7 @@ class ConversationServerBuilder
 public:
     void make_es_object(const std::vector<std::string> host_list) {
         _es_client = ESClientFactory::create(host_list);
+        _es_hosts = host_list;
     }
     void set_redis_seeds(const std::string &seeds) { _redis_seeds = seeds; }
 
@@ -1079,6 +1114,7 @@ public:
         }
         _members_cache = std::make_shared<Members>(_redis_client);
         _last_msg_cache = std::make_shared<LastMessage>(_redis_client);
+        _es_outbox = std::make_shared<ESOutbox>(_redis_client, "im:es:outbox:conversation");
     }
     void make_mysql_object(const std::string &user, const std::string &password,
                            const std::string &host, const std::string &dbname,
@@ -1116,10 +1152,14 @@ public:
         if(!_mm_channels)  { LOG_ERROR("还未初始化信道管理模块"); abort(); }
         if(!_members_cache){ LOG_ERROR("还未初始化Members缓存");  abort(); }
         if(!_last_msg_cache){ LOG_ERROR("还未初始化LastMessage缓存"); abort(); }
+        if(!_es_outbox)   { LOG_ERROR("还未初始化ESOutbox");    abort(); }
 
+        auto es_reaper_client = ESClientFactory::create(_es_hosts);
         auto *impl = new ConversationServiceImpl(
             _es_client, _mysql_client, _members_cache, _last_msg_cache, _mm_channels,
-            _identity_service_name, _media_service_name, _message_service_name, _cfg);
+            _identity_service_name, _media_service_name, _message_service_name, _cfg,
+            _es_outbox, es_reaper_client);
+        _service_impl = impl;
         if(_rpc_server->AddService(impl, brpc::ServiceOwnership::SERVER_OWNS_SERVICE) == -1) {
             LOG_ERROR("添加RPC服务失败!"); abort();
         }
@@ -1142,7 +1182,7 @@ public:
         if(!_reg_client)       { LOG_ERROR("还未初始化服务注册模块"); abort(); }
         if(!_rpc_server)       { LOG_ERROR("还未初始化RPC模块");      abort(); }
         return std::make_shared<ConversationServer>(_service_discover, _reg_client,
-                                                    _mysql_client, _rpc_server);
+                                                    _mysql_client, _rpc_server, _service_impl);
     }
 
 private:
@@ -1160,6 +1200,9 @@ private:
     std::string                             _message_service_name;
     ConversationServiceConfig               _cfg;
     std::shared_ptr<brpc::Server>           _rpc_server;
+    ESOutbox::ptr                           _es_outbox;
+    std::vector<std::string>                _es_hosts;
+    ConversationServiceImpl*                _service_impl = nullptr;
 };
 
 } // namespace chatnow

--- a/conversation/source/conversation_server.h
+++ b/conversation/source/conversation_server.h
@@ -13,6 +13,8 @@
 #include "mq/channel.hpp"
 #include "infra/logger.hpp"
 #include "infra/metrics.hpp"
+#include <thread>
+#include <chrono>
 #include "utils/utils.hpp"
 #include "dao/data_es.hpp"
 #include "dao/data_redis.hpp"
@@ -53,7 +55,9 @@ public:
                             const std::string &identity_service_name,
                             const std::string &media_service_name,
                             const std::string &message_service_name,
-                            const ConversationServiceConfig &cfg)
+                            const ConversationServiceConfig &cfg,
+                            const ESOutbox::ptr &es_outbox,
+                            const std::shared_ptr<elasticlient::Client> &es_reaper_client)
         : _es_conv(std::make_shared<ESConversation>(es_client)),
           _mysql_conv(std::make_shared<ConversationTable>(mysql_client)),
           _mysql_member(std::make_shared<ConversationMemberTable>(mysql_client)),
@@ -63,7 +67,50 @@ public:
           _media_service_name(media_service_name),
           _message_service_name(message_service_name),
           _mm_channels(channel_manager),
-          _cfg(cfg) {}
+          _cfg(cfg),
+          _es_outbox(es_outbox),
+          _es_conv_reaper(std::make_shared<ESConversation>(es_reaper_client)) {}
+
+    /* brief: 解析 Outbox payload 并重放 ES 写入（Reaper 线程调用，使用独立 _es_conv_reaper） */
+    bool replay_es_write_(const std::string &payload) {
+        Json::Value root;
+        if (!UnSerialize(payload, root)) return false;
+        std::string op = root.get("op", "").asString();
+        std::string cid = root.get("cid", "").asString();
+
+        if (op == "upsert") {
+            std::string name = root.get("name", "").asString();
+            int type = root.get("type", 0).asInt();
+            std::string avatar = root.get("avatar", "").asString();
+            int status = root.get("status", 0).asInt();
+            long ut = root.get("ut", 0).asInt64();
+            static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+            boost::posix_time::ptime update_time = epoch + boost::posix_time::seconds(ut);
+
+            chatnow::Conversation ent(cid, name,
+                static_cast<chatnow::ConversationType>(type),
+                update_time, 0, static_cast<chatnow::ConversationStatus>(status));
+            if (!avatar.empty()) ent.avatar_id(avatar);
+
+            std::vector<std::string> mids;
+            const auto &marr = root["mids"];
+            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
+                mids.push_back(marr[i].asString());
+
+            return _es_conv_reaper->append_data(ent, mids);
+        }
+        if (op == "delete") {
+            return _es_conv_reaper->remove(cid);
+        }
+        if (op == "upd_members") {
+            std::vector<std::string> mids;
+            const auto &marr = root["mids"];
+            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
+                mids.push_back(marr[i].asString());
+            return _es_conv_reaper->update_member_ids(cid, mids);
+        }
+        return false;
+    }
 
     ~ConversationServiceImpl() override = default;
 
@@ -886,6 +933,47 @@ private:
         return true;
     }
 
+    static std::string outbox_payload_upsert_(const chatnow::Conversation &c,
+                                               const std::vector<std::string> &mids) {
+        Json::Value root;
+        root["op"] = "upsert";
+        root["cid"] = c.conversation_id();
+        root["name"] = c.conversation_name();
+        root["type"] = static_cast<int>(c.conversation_type());
+        root["avatar"] = c.avatar_id();
+        root["status"] = static_cast<int>(c.status());
+        static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+        root["ut"] = static_cast<Json::Int64>((c.update_time() - epoch).total_seconds());
+        Json::Value marr(Json::arrayValue);
+        for (const auto &uid : mids) marr.append(uid);
+        root["mids"] = marr;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
+
+    static std::string outbox_payload_delete_(const std::string &cid) {
+        Json::Value root;
+        root["op"] = "delete";
+        root["cid"] = cid;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
+
+    static std::string outbox_payload_upd_members_(const std::string &cid,
+                                                    const std::vector<std::string> &mids) {
+        Json::Value root;
+        root["op"] = "upd_members";
+        root["cid"] = cid;
+        Json::Value marr(Json::arrayValue);
+        for (const auto &uid : mids) marr.append(uid);
+        root["mids"] = marr;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
+
 private:
     ESConversation::ptr           _es_conv;
     ConversationTable::ptr        _mysql_conv;
@@ -897,6 +985,29 @@ private:
     std::string                   _message_service_name;
     ServiceManager::ptr           _mm_channels;
     ConversationServiceConfig     _cfg;
+    ESOutbox::ptr                          _es_outbox;
+    ESConversation::ptr                    _es_conv_reaper;
+
+    /* brief: ES 直写 3 次指数退避重试，全失败入 Outbox */
+    bool retry_es_write_(const std::string &outbox_payload,
+                         std::function<bool()> es_op)
+    {
+        for (int i = 0; i < 3; ++i) {
+            if (es_op()) return true;
+            if (i < 2) {
+                metrics::g_es_retry_total << 1;
+                std::this_thread::sleep_for(std::chrono::milliseconds(100 * (1 << i)));
+            }
+        }
+        // 3 次全失败，入 Outbox
+        if (_es_outbox) {
+            auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _es_outbox->enqueue(outbox_payload, static_cast<long long>(now_ms));
+        }
+        metrics::g_degraded_es_write_total << 1;
+        return false;
+    }
 };
 
 class ConversationServer

--- a/conversation/source/conversation_server.h
+++ b/conversation/source/conversation_server.h
@@ -71,47 +71,6 @@ public:
           _es_outbox(es_outbox),
           _es_conv_reaper(std::make_shared<ESConversation>(es_reaper_client)) {}
 
-    /* brief: 解析 Outbox payload 并重放 ES 写入（Reaper 线程调用，使用独立 _es_conv_reaper） */
-    bool replay_es_write_(const std::string &payload) {
-        Json::Value root;
-        if (!UnSerialize(payload, root)) return false;
-        std::string op = root.get("op", "").asString();
-        std::string cid = root.get("cid", "").asString();
-
-        if (op == "upsert") {
-            std::string name = root.get("name", "").asString();
-            int type = root.get("type", 0).asInt();
-            std::string avatar = root.get("avatar", "").asString();
-            int status = root.get("status", 0).asInt();
-            long ut = root.get("ut", 0).asInt64();
-            static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
-            boost::posix_time::ptime update_time = epoch + boost::posix_time::seconds(ut);
-
-            chatnow::Conversation ent(cid, name,
-                static_cast<chatnow::ConversationType>(type),
-                update_time, 0, static_cast<chatnow::ConversationStatus>(status));
-            if (!avatar.empty()) ent.avatar_id(avatar);
-
-            std::vector<std::string> mids;
-            const auto &marr = root["mids"];
-            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
-                mids.push_back(marr[i].asString());
-
-            return _es_conv_reaper->append_data(ent, mids);
-        }
-        if (op == "delete") {
-            return _es_conv_reaper->remove(cid);
-        }
-        if (op == "upd_members") {
-            std::vector<std::string> mids;
-            const auto &marr = root["mids"];
-            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
-                mids.push_back(marr[i].asString());
-            return _es_conv_reaper->update_member_ids(cid, mids);
-        }
-        return false;
-    }
-
     ~ConversationServiceImpl() override = default;
 
     // —— 18 个 RPC 占位实现（T10–T14 逐步替换） ——
@@ -987,6 +946,56 @@ private:
     ConversationServiceConfig     _cfg;
     ESOutbox::ptr                          _es_outbox;
     ESConversation::ptr                    _es_conv_reaper;
+
+    /* brief: 解析 Outbox payload 并重放 ES 写入（Reaper 线程调用，使用独立 _es_conv_reaper） */
+    bool replay_es_write_(const std::string &payload) {
+        if (!_es_conv_reaper) {
+            LOG_ERROR("replay_es_write_ _es_conv_reaper is null");
+            return false;
+        }
+        Json::Value root;
+        if (!UnSerialize(payload, root)) {
+            LOG_WARN("replay_es_write_ failed to deserialize payload: {}", payload);
+            return false;
+        }
+        std::string op = root.get("op", "").asString();
+        std::string cid = root.get("cid", "").asString();
+
+        if (op == "upsert") {
+            std::string name = root.get("name", "").asString();
+            int type = root.get("type", 0).asInt();
+            std::string avatar = root.get("avatar", "").asString();
+            int status = root.get("status", 0).asInt();
+            long ut = root.get("ut", 0).asInt64();
+            static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+            boost::posix_time::ptime update_time = epoch + boost::posix_time::seconds(ut);
+
+            chatnow::Conversation ent(cid, name,
+                static_cast<chatnow::ConversationType>(type),
+                update_time, 0, static_cast<chatnow::ConversationStatus>(status));
+            if (!avatar.empty()) ent.avatar_id(avatar);
+            ent.update_time(update_time);
+
+            std::vector<std::string> mids;
+            const auto &marr = root["mids"];
+            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
+                mids.push_back(marr[i].asString());
+
+            return _es_conv_reaper->append_data(ent, mids);
+        }
+        if (op == "delete") {
+            return _es_conv_reaper->remove(cid);
+        }
+        if (op == "upd_members") {
+            std::vector<std::string> mids;
+            const auto &marr = root["mids"];
+            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
+                mids.push_back(marr[i].asString());
+            return _es_conv_reaper->update_member_ids(cid, mids);
+        }
+        LOG_WARN("replay_es_write_ unknown op '{}' for cid={}", op, cid);
+        return false;
+    }
 
     /* brief: ES 直写 3 次指数退避重试，全失败入 Outbox */
     bool retry_es_write_(const std::string &outbox_payload,

--- a/conversation/source/conversation_server.h
+++ b/conversation/source/conversation_server.h
@@ -186,8 +186,10 @@ public:
             all_member_ids.push_back(auth.user_id);
             for (int i = 0; i < req->member_ids_size(); ++i)
                 all_member_ids.push_back(req->member_ids(i));
-            if (!_es_conv->append_data(ent, all_member_ids))
-                metrics::g_degraded_es_write_total << 1;
+            std::string ob_payload = outbox_payload_upsert_(ent, all_member_ids);
+            retry_es_write_(ob_payload, [&]() {
+                return _es_conv->append_data(ent, all_member_ids);
+            });
 
             // 回填响应
             auto* out = rsp->mutable_conversation();
@@ -230,8 +232,10 @@ public:
                 throw ServiceError(::chatnow::error::kSystemInternalError,
                                    "update failed");
             auto uids = _mysql_member->members(req->conversation_id());
-            if (!_es_conv->append_data(*c, uids))
-                metrics::g_degraded_es_write_total << 1;
+            std::string ob_payload = outbox_payload_upsert_(*c, uids);
+            retry_es_write_(ob_payload, [&]() {
+                return _es_conv->append_data(*c, uids);
+            });
 
             auto* out = rsp->mutable_conversation();
             out->set_conversation_id(c->conversation_id());
@@ -260,8 +264,10 @@ public:
                                            ::chatnow::ConversationStatus::DISMISSED))
                 throw ServiceError(::chatnow::error::kSystemInternalError,
                                    "update_status failed");
-            if (!_es_conv->remove(req->conversation_id()))
-                metrics::g_degraded_es_write_total << 1;
+            std::string ob_payload = outbox_payload_delete_(req->conversation_id());
+            retry_es_write_(ob_payload, [&]() {
+                return _es_conv->remove(req->conversation_id());
+            });
             invalidate_members_cache_(req->conversation_id());
             // 推送 CONVERSATION_DISMISSED_NOTIFY 留待 Push 接入；本期 fail-soft 不推
         });
@@ -288,9 +294,13 @@ public:
                                    "set_quit failed");
             invalidate_members_cache_(req->conversation_id());
             auto updated_uids = _mysql_member->members(req->conversation_id());
-            if (!updated_uids.empty() &&
-                !_es_conv->update_member_ids(req->conversation_id(), updated_uids))
-                metrics::g_degraded_es_write_total << 1;
+            if (!updated_uids.empty()) {
+                std::string ob_payload = outbox_payload_upd_members_(
+                    req->conversation_id(), updated_uids);
+                retry_es_write_(ob_payload, [&]() {
+                    return _es_conv->update_member_ids(req->conversation_id(), updated_uids);
+                });
+            }
             // set_quit 内部已经维护 member_count（_update_session_member_count(-1)），
             // 不需要再 _mysql_conv->update。
         });
@@ -352,9 +362,13 @@ public:
             }
             invalidate_members_cache_(req->conversation_id());
             auto updated_uids = _mysql_member->members(req->conversation_id());
-            if (!updated_uids.empty() &&
-                !_es_conv->update_member_ids(req->conversation_id(), updated_uids))
-                metrics::g_degraded_es_write_total << 1;
+            if (!updated_uids.empty()) {
+                std::string ob_payload = outbox_payload_upd_members_(
+                    req->conversation_id(), updated_uids);
+                retry_es_write_(ob_payload, [&]() {
+                    return _es_conv->update_member_ids(req->conversation_id(), updated_uids);
+                });
+            }
         });
     }
 
@@ -387,9 +401,13 @@ public:
             if (removed > 0) {
                 invalidate_members_cache_(req->conversation_id());
                 auto updated_uids = _mysql_member->members(req->conversation_id());
-                if (!updated_uids.empty() &&
-                    !_es_conv->update_member_ids(req->conversation_id(), updated_uids))
-                    metrics::g_degraded_es_write_total << 1;
+                if (!updated_uids.empty()) {
+                    std::string ob_payload = outbox_payload_upd_members_(
+                        req->conversation_id(), updated_uids);
+                    retry_es_write_(ob_payload, [&]() {
+                        return _es_conv->update_member_ids(req->conversation_id(), updated_uids);
+                    });
+                }
             }
         });
     }

--- a/docs/superpowers/plans/2026-05-21-es-mysql-consistency.md
+++ b/docs/superpowers/plans/2026-05-21-es-mysql-consistency.md
@@ -1,0 +1,1027 @@
+# ES-MySQL 一致性 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 Conversation 和 Identity 服务的 ES 写入增加重试 + Redis Outbox 兜底，消除 ES 写入静默失败导致的不一致。
+
+**Architecture:** ES 直写 3 次指数退避重试，全部失败后事件入 Redis ESOutbox。独立 Reaper 线程每 5 秒从 Outbox 取出重放。ESOutbox key 按服务隔离。Reaper 使用独立 elasticlient::Client 保证线程安全。
+
+**Tech Stack:** C++17, elasticlient, sw::redis++, jsoncpp, bvar
+
+**Spec:** `docs/superpowers/specs/2026-05-21-es-mysql-consistency-design.md`
+
+---
+
+## File Map
+
+| 文件 | 职责 |
+|------|------|
+| `common/dao/data_redis.hpp` | ESOutbox 支持自定义 Redis key |
+| `common/infra/metrics.hpp` | 新增 `g_es_retry_total` bvar |
+| `conversation/source/conversation_server.h` | 接入 Outbox + 重试 + Reaper |
+| `identity/source/identity_server.h` | 接入 Outbox + 重试 + Reaper |
+
+---
+
+### Task 1: ESOutbox 支持自定义 key
+
+**Files:**
+- Modify: `common/dao/data_redis.hpp:834-861`
+
+- [ ] **Step 1: 新增带 key 参数的构造函数**
+
+在 `ESOutbox` 类中，`public:` 区域（`using ptr = ...` 之后，`ESOutbox(const RedisClient::ptr &c)` 之前）新增：
+
+```cpp
+    ESOutbox(const RedisClient::ptr &c, const std::string &key)
+        : _c(c), _key(key) {}
+```
+
+- [ ] **Step 2: 将 `kEsOutboxKey` 改为成员变量**
+
+把 `private:` 区的：
+
+```cpp
+    static constexpr const char *kEsOutboxKey     = "im:es:outbox";
+```
+
+改为：
+
+```cpp
+    std::string _key;
+```
+
+- [ ] **Step 3: 修改 `enqueue`、`peek`、`remove` 使用 `_key`**
+
+将三个方法中的 `kEsOutboxKey` 替换为 `_key`：
+
+```cpp
+    void enqueue(const std::string &payload, long long score_ts) {
+        try { _c->zadd(_key, payload, static_cast<double>(score_ts)); }
+        catch(std::exception &e) { LOG_ERROR("ESOutbox.enqueue 失败: {}", e.what()); }
+    }
+
+    std::vector<std::string> peek(long limit = 50) {
+        std::vector<std::string> res;
+        try {
+            _c->zrange(_key, 0, limit - 1, std::back_inserter(res));
+        } catch(std::exception &e) { LOG_ERROR("ESOutbox.peek 失败: {}", e.what()); }
+        return res;
+    }
+
+    void remove(const std::string &payload) {
+        try { _c->zrem(_key, payload); }
+        catch(std::exception &e) { LOG_ERROR("ESOutbox.remove 失败: {}", e.what()); }
+    }
+```
+
+- [ ] **Step 4: 保留旧构造函数兼容性（Message 服务）**
+
+旧构造函数 `ESOutbox(const RedisClient::ptr &c)` 保持不变，通过默认参数传给新构造函数：
+
+```cpp
+    ESOutbox(const RedisClient::ptr &c) : ESOutbox(c, "im:es:outbox") {}
+```
+
+确保 Message 服务编译不受影响。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add common/dao/data_redis.hpp
+git commit -m "feat(es): support custom Redis key in ESOutbox"
+```
+
+---
+
+### Task 2: 新增 g_es_retry_total 指标
+
+**Files:**
+- Modify: `common/infra/metrics.hpp`
+
+- [ ] **Step 1: 新增 bvar**
+
+在 `g_degraded_es_write_total` 之后新增：
+
+```cpp
+inline bvar::Adder<long> g_es_retry_total;
+```
+
+- [ ] **Step 2: 提交**
+
+```bash
+git add common/infra/metrics.hpp
+git commit -m "feat(metrics): add g_es_retry_total counter"
+```
+
+---
+
+### Task 3: Conversation 服务 — 重试逻辑 + Outbox 序列化
+
+**Files:**
+- Modify: `conversation/source/conversation_server.h`
+
+- [ ] **Step 1: 新增 include**
+
+在现有 include 区域（`#include "infra/metrics.hpp"` 之后）新增：
+
+```cpp
+#include <thread>
+#include <chrono>
+```
+
+- [ ] **Step 2: 新增成员变量和构造函数参数**
+
+在 `ConversationServiceImpl` 类中：
+
+**构造函数签名** — 在末尾新增两个参数：
+
+```cpp
+    ConversationServiceImpl(const std::shared_ptr<elasticlient::Client> &es_client,
+                            const std::shared_ptr<odb::core::database> &mysql_client,
+                            const Members::ptr &members_cache,
+                            const LastMessage::ptr &last_msg_cache,
+                            const ServiceManager::ptr &channel_manager,
+                            const std::string &identity_service_name,
+                            const std::string &media_service_name,
+                            const std::string &message_service_name,
+                            const ConversationServiceConfig &cfg,
+                            const ESOutbox::ptr &es_outbox,
+                            const std::shared_ptr<elasticlient::Client> &es_reaper_client)
+```
+
+**初始化列表** — 新增两行：
+
+```cpp
+        : _es_conv(std::make_shared<ESConversation>(es_client)),
+          ...
+          _cfg(cfg),
+          _es_outbox(es_outbox),
+          _es_conv_reaper(std::make_shared<ESConversation>(es_reaper_client)) {}
+```
+
+**成员变量** — 在 `private:` 区末尾新增：
+
+```cpp
+    ESOutbox::ptr                          _es_outbox;
+    ESConversation::ptr                    _es_conv_reaper;
+```
+
+- [ ] **Step 3: 新增 `retry_es_write_` 辅助方法**
+
+在 `private:` 区，`_cfg` 声明之后新增：
+
+```cpp
+    /* brief: ES 直写 3 次指数退避重试，全失败入 Outbox */
+    bool retry_es_write_(const std::string &outbox_payload,
+                         std::function<bool()> es_op)
+    {
+        for (int i = 0; i < 3; ++i) {
+            if (es_op()) return true;
+            if (i < 2) {
+                metrics::g_es_retry_total << 1;
+                std::this_thread::sleep_for(std::chrono::milliseconds(100 * (1 << i)));
+            }
+        }
+        // 3 次全失败，入 Outbox
+        if (_es_outbox) {
+            auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _es_outbox->enqueue(outbox_payload, static_cast<long long>(now_ms));
+        }
+        metrics::g_degraded_es_write_total << 1;
+        return false;
+    }
+```
+
+- [ ] **Step 4: 新增 Outbox payload 序列化辅助方法**
+
+在 `parse_preview_json_` 之后新增三个静态方法：
+
+```cpp
+    static std::string serialize_member_ids_json_(const std::vector<std::string> &mids) {
+        Json::Value arr(Json::arrayValue);
+        for (const auto &uid : mids) arr.append(uid);
+        std::string dst;
+        Serialize(arr, dst);
+        return dst;
+    }
+
+    /* Outbox payload formats:
+     *   upsert:  {"op":"upsert","cid":"...","name":"...","type":0,"avatar":"...","status":0,"ut":123,"mids":[...]}
+     *   delete:  {"op":"delete","cid":"..."}
+     *   upd_mem: {"op":"upd_members","cid":"...","mids":[...]}
+     */
+    static std::string outbox_payload_upsert_(const chatnow::Conversation &c,
+                                               const std::vector<std::string> &mids) {
+        Json::Value root;
+        root["op"] = "upsert";
+        root["cid"] = c.conversation_id();
+        root["name"] = c.conversation_name();
+        root["type"] = static_cast<int>(c.conversation_type());
+        root["avatar"] = c.avatar_id();
+        root["status"] = static_cast<int>(c.status());
+        static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+        root["ut"] = static_cast<Json::Int64>((c.update_time() - epoch).total_seconds());
+        // member_ids JSON
+        Json::Value marr(Json::arrayValue);
+        for (const auto &uid : mids) marr.append(uid);
+        root["mids"] = marr;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
+
+    static std::string outbox_payload_delete_(const std::string &cid) {
+        Json::Value root;
+        root["op"] = "delete";
+        root["cid"] = cid;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
+
+    static std::string outbox_payload_upd_members_(const std::string &cid,
+                                                    const std::vector<std::string> &mids) {
+        Json::Value root;
+        root["op"] = "upd_members";
+        root["cid"] = cid;
+        Json::Value marr(Json::arrayValue);
+        for (const auto &uid : mids) marr.append(uid);
+        root["mids"] = marr;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
+```
+
+- [ ] **Step 5: 新增 Reaper 用 `replay_es_write_` 方法**
+
+在 `retry_es_write_` 之后新增（public 区或 private 区，Reaper 需要访问）：
+
+```cpp
+    /* brief: 解析 Outbox payload 并重放 ES 写入（Reaper 线程调用，使用独立 _es_conv_reaper） */
+    bool replay_es_write_(const std::string &payload) {
+        Json::Value root;
+        if (!UnSerialize(payload, root)) return false;
+        std::string op = root.get("op", "").asString();
+        std::string cid = root.get("cid", "").asString();
+
+        if (op == "upsert") {
+            std::string name = root.get("name", "").asString();
+            int type = root.get("type", 0).asInt();
+            std::string avatar = root.get("avatar", "").asString();
+            int status = root.get("status", 0).asInt();
+            long ut = root.get("ut", 0).asInt64();
+            static const boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+            boost::posix_time::ptime update_time = epoch + boost::posix_time::seconds(ut);
+
+            chatnow::Conversation ent(cid, name,
+                static_cast<chatnow::ConversationType>(type),
+                update_time, 0, static_cast<chatnow::ConversationStatus>(status));
+            if (!avatar.empty()) ent.avatar_id(avatar);
+
+            std::vector<std::string> mids;
+            const auto &marr = root["mids"];
+            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
+                mids.push_back(marr[i].asString());
+
+            return _es_conv_reaper->append_data(ent, mids);
+        }
+        if (op == "delete") {
+            return _es_conv_reaper->remove(cid);
+        }
+        if (op == "upd_members") {
+            std::vector<std::string> mids;
+            const auto &marr = root["mids"];
+            for (Json::ArrayIndex i = 0; i < marr.size(); ++i)
+                mids.push_back(marr[i].asString());
+            return _es_conv_reaper->update_member_ids(cid, mids);
+        }
+        return false;
+    }
+```
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add conversation/source/conversation_server.h
+git commit -m "feat(conversation): add ES retry logic, outbox serialization, and replay"
+```
+
+---
+
+### Task 4: Conversation 服务 — 改造 6 个 ES 写入点
+
+**Files:**
+- Modify: `conversation/source/conversation_server.h`
+
+- [ ] **Step 1: 改造 CreateConversation（lines 183-184）**
+
+将：
+
+```cpp
+            if (!_es_conv->append_data(ent, all_member_ids))
+                metrics::g_degraded_es_write_total << 1;
+```
+
+改为：
+
+```cpp
+            std::string ob_payload = outbox_payload_upsert_(ent, all_member_ids);
+            retry_es_write_(ob_payload, [&]() {
+                return _es_conv->append_data(ent, all_member_ids);
+            });
+```
+
+- [ ] **Step 2: 改造 UpdateConversation（lines 227-228）**
+
+将：
+
+```cpp
+            if (!_es_conv->append_data(*c, uids))
+                metrics::g_degraded_es_write_total << 1;
+```
+
+改为：
+
+```cpp
+            std::string ob_payload = outbox_payload_upsert_(*c, uids);
+            retry_es_write_(ob_payload, [&]() {
+                return _es_conv->append_data(*c, uids);
+            });
+```
+
+- [ ] **Step 3: 改造 DismissConversation（lines 257-258）**
+
+将：
+
+```cpp
+            if (!_es_conv->remove(req->conversation_id()))
+                metrics::g_degraded_es_write_total << 1;
+```
+
+改为：
+
+```cpp
+            std::string ob_payload = outbox_payload_delete_(req->conversation_id());
+            retry_es_write_(ob_payload, [&]() {
+                return _es_conv->remove(req->conversation_id());
+            });
+```
+
+- [ ] **Step 4: 改造 QuitConversation（lines 285-287）**
+
+将：
+
+```cpp
+            if (!updated_uids.empty() &&
+                !_es_conv->update_member_ids(req->conversation_id(), updated_uids))
+                metrics::g_degraded_es_write_total << 1;
+```
+
+改为：
+
+```cpp
+            if (!updated_uids.empty()) {
+                std::string ob_payload = outbox_payload_upd_members_(
+                    req->conversation_id(), updated_uids);
+                retry_es_write_(ob_payload, [&]() {
+                    return _es_conv->update_member_ids(req->conversation_id(), updated_uids);
+                });
+            }
+```
+
+- [ ] **Step 5: 改造 AddMembers（lines 349-351）**
+
+将：
+
+```cpp
+            if (!updated_uids.empty() &&
+                !_es_conv->update_member_ids(req->conversation_id(), updated_uids))
+                metrics::g_degraded_es_write_total << 1;
+```
+
+改为：
+
+```cpp
+            if (!updated_uids.empty()) {
+                std::string ob_payload = outbox_payload_upd_members_(
+                    req->conversation_id(), updated_uids);
+                retry_es_write_(ob_payload, [&]() {
+                    return _es_conv->update_member_ids(req->conversation_id(), updated_uids);
+                });
+            }
+```
+
+- [ ] **Step 6: 改造 RemoveMembers（lines 384-386）**
+
+将：
+
+```cpp
+                if (!updated_uids.empty() &&
+                    !_es_conv->update_member_ids(req->conversation_id(), updated_uids))
+                    metrics::g_degraded_es_write_total << 1;
+```
+
+改为：
+
+```cpp
+                if (!updated_uids.empty()) {
+                    std::string ob_payload = outbox_payload_upd_members_(
+                        req->conversation_id(), updated_uids);
+                    retry_es_write_(ob_payload, [&]() {
+                        return _es_conv->update_member_ids(req->conversation_id(), updated_uids);
+                    });
+                }
+```
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add conversation/source/conversation_server.h
+git commit -m "feat(conversation): add retry+outbox to all 6 ES write sites"
+```
+
+---
+
+### Task 5: Conversation 服务 — Builder 接入 + Reaper 线程
+
+**Files:**
+- Modify: `conversation/source/conversation_server.h`
+
+- [ ] **Step 1: 在 ConversationServer 类中加入 Reaper 管理**
+
+修改 `ConversationServer` 类（lines 902-923）：
+
+```cpp
+class ConversationServer
+{
+public:
+    using ptr = std::shared_ptr<ConversationServer>;
+    ConversationServer(const Discovery::ptr &service_discover,
+                       const Registry::ptr &reg_client,
+                       const std::shared_ptr<odb::core::database> &mysql_client,
+                       const std::shared_ptr<brpc::Server> &server,
+                       const ESOutbox::ptr &es_outbox,
+                       const std::shared_ptr<ESConversation> &es_conv_reaper)
+        : _service_discover(service_discover),
+          _reg_client(reg_client),
+          _mysql_client(mysql_client),
+          _rpc_server(server),
+          _es_outbox(es_outbox),
+          _es_conv_reaper(es_conv_reaper) {}
+
+    ~ConversationServer() {
+        if (_es_reaper_running) *_es_reaper_running = false;
+        if (_es_reaper_thread && _es_reaper_thread->joinable())
+            _es_reaper_thread->join();
+    }
+    void start() { _rpc_server->RunUntilAskedToQuit(); }
+
+    void start_es_outbox_reaper() {
+        _es_reaper_running = std::make_shared<std::atomic<bool>>(true);
+        _es_reaper_thread = std::make_shared<std::thread>([this]() {
+            while (*_es_reaper_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                try {
+                    auto items = _es_outbox->peek(50);
+                    for (const auto &item : items) {
+                        if (_es_conv_reaper->replay_es_write_(item))
+                            _es_outbox->remove(item);
+                    }
+                } catch (std::exception &e) {
+                    LOG_WARN("ESOutbox reaper 异常: {}", e.what());
+                }
+            }
+        });
+    }
+
+private:
+    Discovery::ptr _service_discover;
+    Registry::ptr  _reg_client;
+    std::shared_ptr<odb::core::database> _mysql_client;
+    std::shared_ptr<brpc::Server>        _rpc_server;
+    ESOutbox::ptr                        _es_outbox;
+    std::shared_ptr<ESConversation>      _es_conv_reaper;
+    std::shared_ptr<std::atomic<bool>>   _es_reaper_running;
+    std::shared_ptr<std::thread>         _es_reaper_thread;
+};
+```
+
+注意：`replay_es_write_` 是 `ConversationServiceImpl` 的方法，但 Reaper 在 `ConversationServer` 中。需要调整架构——把 `replay_es_write_` 变为 `ESConversation` 的方法，或者把 Reaper 放到 `ConversationServiceImpl` 中。
+
+**更简单的方案：** 把 Reaper 放到 `ConversationServiceImpl` 中，因为 `replay_es_write_` 需要访问 ES 方法。ConversationServer 只负责生命周期。
+
+修改 `ConversationServiceImpl`：
+
+在 `public:` 区新增：
+
+```cpp
+    void start_es_outbox_reaper() {
+        _es_reaper_running = std::make_shared<std::atomic<bool>>(true);
+        _es_reaper_thread = std::make_shared<std::thread>([this]() {
+            while (*_es_reaper_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                try {
+                    auto items = _es_outbox->peek(50);
+                    for (const auto &item : items) {
+                        if (replay_es_write_(item))
+                            _es_outbox->remove(item);
+                    }
+                } catch (std::exception &e) {
+                    LOG_WARN("ESOutbox reaper 异常: {}", e.what());
+                }
+            }
+        });
+    }
+
+    void stop_es_outbox_reaper() {
+        if (_es_reaper_running) *_es_reaper_running = false;
+        if (_es_reaper_thread && _es_reaper_thread->joinable())
+            _es_reaper_thread->join();
+    }
+```
+
+在 `private:` 区新增：
+
+```cpp
+    std::shared_ptr<std::atomic<bool>>   _es_reaper_running;
+    std::shared_ptr<std::thread>         _es_reaper_thread;
+```
+
+`ConversationServer` 保持简洁，在析构时调 `stop_es_outbox_reaper()`：
+
+```cpp
+class ConversationServer
+{
+public:
+    using ptr = std::shared_ptr<ConversationServer>;
+    ConversationServer(const Discovery::ptr &service_discover,
+                       const Registry::ptr &reg_client,
+                       const std::shared_ptr<odb::core::database> &mysql_client,
+                       const std::shared_ptr<brpc::Server> &server,
+                       ConversationServiceImpl *impl)
+        : _service_discover(service_discover),
+          _reg_client(reg_client),
+          _mysql_client(mysql_client),
+          _rpc_server(server),
+          _impl(impl) {}
+
+    ~ConversationServer() {
+        if (_impl) _impl->stop_es_outbox_reaper();
+    }
+    void start() {
+        if (_impl) _impl->start_es_outbox_reaper();
+        _rpc_server->RunUntilAskedToQuit();
+    }
+
+private:
+    Discovery::ptr _service_discover;
+    Registry::ptr  _reg_client;
+    std::shared_ptr<odb::core::database> _mysql_client;
+    std::shared_ptr<brpc::Server>        _rpc_server;
+    ConversationServiceImpl*             _impl = nullptr;
+};
+```
+
+- [ ] **Step 2: 修改 ConversationServerBuilder**
+
+在 `make_redis_object` 末尾新增 Outbox 创建：
+
+```cpp
+    void make_redis_object(const std::string &host, uint16_t port, int db,
+                           bool keep_alive, int pool_size) {
+        // ... 现有代码 ...
+        _members_cache = std::make_shared<Members>(_redis_client);
+        _last_msg_cache = std::make_shared<LastMessage>(_redis_client);
+        _es_outbox = std::make_shared<ESOutbox>(_redis_client, "im:es:outbox:conversation");
+    }
+```
+
+在 `make_rpc_object` 中，传入 outbox 并为 Reaper 创建独立 ES Client：
+
+```cpp
+    void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads) {
+        _rpc_server = std::make_shared<brpc::Server>();
+        // ... 现有检查 ...
+        if(!_es_outbox)   { LOG_ERROR("还未初始化ESOutbox");    abort(); }
+
+        // Reaper 用独立 ES client
+        auto es_reaper_client = ESClientFactory::create(_es_hosts);
+
+        auto *impl = new ConversationServiceImpl(
+            _es_client, _mysql_client, _members_cache, _last_msg_cache, _mm_channels,
+            _identity_service_name, _media_service_name, _message_service_name, _cfg,
+            _es_outbox, es_reaper_client);
+        // ... 其余不变 ...
+    }
+```
+
+注意：需要在 Builder 中保存 `_es_hosts`。修改 `make_es_object`：
+
+```cpp
+    void make_es_object(const std::vector<std::string> host_list) {
+        _es_client = ESClientFactory::create(host_list);
+        _es_hosts = host_list;
+    }
+```
+
+修改 `build()` — 传入 impl 指针：
+
+```cpp
+    ConversationServer::ptr build() {
+        // ... 现有检查 ...
+        return std::make_shared<ConversationServer>(_service_discover, _reg_client,
+                                                    _mysql_client, _rpc_server, _service_impl);
+    }
+```
+
+修改 `make_rpc_object` — 保存 impl 指针：
+
+```cpp
+        auto *impl = new ConversationServiceImpl(...);
+        _service_impl = impl;
+        // ... AddService ...
+```
+
+在 Builder `private:` 区新增成员：
+
+```cpp
+    ESOutbox::ptr                           _es_outbox;
+    std::vector<std::string>                _es_hosts;
+    ConversationServiceImpl*                _service_impl = nullptr;
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add conversation/source/conversation_server.h
+git commit -m "feat(conversation): add ESOutbox reaper thread and builder integration"
+```
+
+---
+
+### Task 6: Identity 服务 — 重试逻辑 + Outbox + 改造写入点
+
+**Files:**
+- Modify: `identity/source/identity_server.h`
+
+- [ ] **Step 1: 新增 include**
+
+在 `#include "dao/data_redis.hpp"` 之后新增：
+
+```cpp
+#include "infra/metrics.hpp"
+#include <thread>
+#include <chrono>
+```
+
+- [ ] **Step 2: 修改 IdentityServiceImpl 构造函数和成员**
+
+构造函数签名新增 `es_outbox` 和 `es_reaper_client` 参数：
+
+```cpp
+    IdentityServiceImpl(const std::shared_ptr<odb::core::database> &mysql_client,
+                        const std::shared_ptr<elasticlient::Client> &es_client,
+                        const RedisClient::ptr &redis_client,
+                        const std::shared_ptr<MailClient> &mail_client,
+                        const std::shared_ptr<auth::JwtCodec> &jwt_codec,
+                        const std::shared_ptr<auth::JwtStore> &jwt_store,
+                        const std::string &media_public_url_prefix,
+                        const ESOutbox::ptr &es_outbox,
+                        const std::shared_ptr<elasticlient::Client> &es_reaper_client)
+        : _mysql_user(std::make_shared<UserTable>(mysql_client)),
+          _es_user(std::make_shared<ESUser>(es_client)),
+          _redis_codes(std::make_shared<Codes>(redis_client)),
+          _mail_client(mail_client),
+          _jwt_codec(jwt_codec),
+          _jwt_store(jwt_store),
+          _media_public_url_prefix(media_public_url_prefix),
+          _es_outbox(es_outbox),
+          _es_user_reaper(std::make_shared<ESUser>(es_reaper_client))
+    {
+        _es_user->create_index();
+    }
+```
+
+- [ ] **Step 3: 新增 `retry_es_write_` 辅助方法**
+
+在 `private:` 区新增：
+
+```cpp
+    bool retry_es_write_(const std::string &outbox_payload,
+                         std::function<bool()> es_op)
+    {
+        for (int i = 0; i < 3; ++i) {
+            if (es_op()) return true;
+            if (i < 2) {
+                metrics::g_es_retry_total << 1;
+                std::this_thread::sleep_for(std::chrono::milliseconds(100 * (1 << i)));
+            }
+        }
+        if (_es_outbox) {
+            auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _es_outbox->enqueue(outbox_payload, static_cast<long long>(now_ms));
+        }
+        metrics::g_degraded_es_write_total << 1;
+        return false;
+    }
+```
+
+- [ ] **Step 4: 新增 Outbox payload 序列化方法**
+
+```cpp
+    static std::string outbox_payload_upsert_(const std::string &uid,
+                                               const std::string &mail,
+                                               const std::string &phone,
+                                               const std::string &nickname,
+                                               const std::string &description,
+                                               const std::string &avatar_id,
+                                               int status) {
+        Json::Value root;
+        root["op"] = "upsert";
+        root["uid"] = uid;
+        root["mail"] = mail;
+        root["phone"] = phone;
+        root["nick"] = nickname;
+        root["desc"] = description;
+        root["avatar"] = avatar_id;
+        root["status"] = status;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
+```
+
+- [ ] **Step 5: 新增 `replay_es_write_` 方法**
+
+```cpp
+    bool replay_es_write_(const std::string &payload) {
+        Json::Value root;
+        if (!UnSerialize(payload, root)) return false;
+        std::string op = root.get("op", "").asString();
+        if (op == "upsert") {
+            return _es_user_reaper->append_data(
+                root.get("uid", "").asString(),
+                root.get("mail", "").asString(),
+                root.get("phone", "").asString(),
+                root.get("nick", "").asString(),
+                root.get("desc", "").asString(),
+                root.get("avatar", "").asString(),
+                root.get("status", 0).asInt());
+        }
+        return false;
+    }
+```
+
+- [ ] **Step 6: 改造 Register handler（line 275）**
+
+将：
+
+```cpp
+                _es_user->append_data(user_id, "", phone, nickname, "", "");
+```
+
+改为：
+
+```cpp
+                std::string ob_payload = outbox_payload_upsert_(
+                    user_id, "", phone, nickname, "", "", 0);
+                retry_es_write_(ob_payload, [&]() {
+                    return _es_user->append_data(user_id, "", phone, nickname, "", "");
+                });
+```
+
+- [ ] **Step 7: 改造 UpdateProfile handler（lines 421-423）**
+
+将：
+
+```cpp
+            _es_user->append_data(user->user_id(), user->mail(), user->phone(),
+                                  user->nickname(), user->description(),
+                                  user->avatar_id());
+```
+
+改为：
+
+```cpp
+            std::string ob_payload = outbox_payload_upsert_(
+                user->user_id(), user->mail(), user->phone(),
+                user->nickname(), user->description(),
+                user->avatar_id(), 0);
+            retry_es_write_(ob_payload, [&]() {
+                return _es_user->append_data(user->user_id(), user->mail(), user->phone(),
+                                             user->nickname(), user->description(),
+                                             user->avatar_id());
+            });
+```
+
+- [ ] **Step 8: 新增 Reaper 管理方法（public 区）**
+
+```cpp
+    void start_es_outbox_reaper() {
+        _es_reaper_running = std::make_shared<std::atomic<bool>>(true);
+        _es_reaper_thread = std::make_shared<std::thread>([this]() {
+            while (*_es_reaper_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                try {
+                    auto items = _es_outbox->peek(50);
+                    for (const auto &item : items) {
+                        if (replay_es_write_(item))
+                            _es_outbox->remove(item);
+                    }
+                } catch (std::exception &e) {
+                    LOG_WARN("ESOutbox reaper 异常: {}", e.what());
+                }
+            }
+        });
+    }
+
+    void stop_es_outbox_reaper() {
+        if (_es_reaper_running) *_es_reaper_running = false;
+        if (_es_reaper_thread && _es_reaper_thread->joinable())
+            _es_reaper_thread->join();
+    }
+```
+
+- [ ] **Step 9: 新增成员变量（private 区）**
+
+```cpp
+    ESOutbox::ptr                          _es_outbox;
+    std::shared_ptr<ESUser>                _es_user_reaper;
+    std::shared_ptr<std::atomic<bool>>     _es_reaper_running;
+    std::shared_ptr<std::thread>           _es_reaper_thread;
+```
+
+- [ ] **Step 10: 提交**
+
+```bash
+git add identity/source/identity_server.h
+git commit -m "feat(identity): add ES retry+outbox and reaper for Register/UpdateProfile"
+```
+
+---
+
+### Task 7: Identity 服务 — Builder 接入 + Reaper 启动
+
+**Files:**
+- Modify: `identity/source/identity_server.h`
+
+- [ ] **Step 1: 修改 IdentityServer 启动 Reaper**
+
+```cpp
+class IdentityServer
+{
+public:
+    using ptr = std::shared_ptr<IdentityServer>;
+
+    IdentityServer(const Discovery::ptr &service_discover,
+            const Registry::ptr &reg_client,
+            const std::shared_ptr<elasticlient::Client> &es_client,
+            const std::shared_ptr<odb::core::database> &mysql_client,
+            const RedisClient::ptr &redis_client,
+            const std::shared_ptr<brpc::Server> &server,
+            IdentityServiceImpl *impl)
+        : _service_discover(service_discover),
+        _reg_client(reg_client),
+        _es_client(es_client),
+        _mysql_client(mysql_client),
+        _redis_client(redis_client),
+        _rpc_server(server),
+        _impl(impl) {}
+
+    ~IdentityServer() {
+        if (_impl) _impl->stop_es_outbox_reaper();
+    }
+    void start() {
+        if (_impl) _impl->start_es_outbox_reaper();
+        _rpc_server->RunUntilAskedToQuit();
+    }
+private:
+    Discovery::ptr _service_discover;
+    Registry::ptr _reg_client;
+    std::shared_ptr<brpc::Server> _rpc_server;
+    std::shared_ptr<elasticlient::Client> _es_client;
+    std::shared_ptr<odb::core::database> _mysql_client;
+    RedisClient::ptr _redis_client;
+    IdentityServiceImpl* _impl = nullptr;
+};
+```
+
+- [ ] **Step 2: 修改 IdentityServerBuilder**
+
+`make_redis_object` 末尾新增 Outbox：
+
+```cpp
+    void make_redis_object(...) {
+        // ... 现有代码 ...
+        _es_outbox = std::make_shared<ESOutbox>(_redis_client, "im:es:outbox:identity");
+    }
+```
+
+`make_es_object` 保存 host_list：
+
+```cpp
+    void make_es_object(const std::vector<std::string> host_list) {
+        _es_client = ESClientFactory::create(host_list);
+        _es_hosts = host_list;
+    }
+```
+
+`make_rpc_object` 传入 outbox + reaper client：
+
+```cpp
+    void make_rpc_object(uint16_t port, uint32_t timeout, uint8_t num_threads) {
+        // ... 现有检查 ...
+        if(!_es_outbox) { LOG_ERROR("还未初始化ESOutbox"); abort(); }
+
+        auto es_reaper_client = ESClientFactory::create(_es_hosts);
+
+        IdentityServiceImpl *identity_service = new IdentityServiceImpl(
+            _mysql_client, _es_client, _redis_client, _mail_client,
+            _jwt_codec, _jwt_store, _media_public_url_prefix,
+            _es_outbox, es_reaper_client);
+        _service_impl = identity_service;
+        // ... AddService ...
+    }
+```
+
+`build()` 传入 impl：
+
+```cpp
+    IdentityServer::ptr build() {
+        // ... 现有检查 ...
+        IdentityServer::ptr server = std::make_shared<IdentityServer>(
+            _service_discover, _reg_client, _es_client, _mysql_client, _redis_client,
+            _rpc_server, _service_impl);
+        return server;
+    }
+```
+
+Builder `private:` 区新增：
+
+```cpp
+    ESOutbox::ptr                           _es_outbox;
+    std::vector<std::string>                _es_hosts;
+    IdentityServiceImpl*                    _service_impl = nullptr;
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add identity/source/identity_server.h
+git commit -m "feat(identity): add ESOutbox reaper and builder integration"
+```
+
+---
+
+### Task 8: 编译验证
+
+- [ ] **Step 1: 编译**
+
+```bash
+cd build && cmake .. && make -j$(sysctl -n hw.logicalcpu)
+```
+
+确认 0 错误 0 警告。
+
+- [ ] **Step 2: 确认 Message 服务编译不受影响**
+
+检查 Message 服务的 ESOutbox 用法（`ESOutbox(const RedisClient::ptr &c)`）仍然编译通过。
+
+- [ ] **Step 3: 提交（如有编译修复）**
+
+```bash
+git add -u
+git commit -m "fix: compile fixes for ES retry+outbox"
+```
+
+---
+
+## 验证检查点
+
+全部任务完成后：
+
+```bash
+# 1. 编译检查
+cd build && cmake .. && make -j$(sysctl -n hw.logicalcpu)
+
+# 2. 确认无新增编译警告
+```
+
+---
+
+## 任务依赖
+
+```
+Task1 (ESOutbox key) ──┐
+Task2 (metrics)        ├── Task3 (Conversation 重试) ── Task4 (改造写入点) ── Task5 (Reaper)
+                       │
+                       ├── Task6 (Identity 重试+写入) ── Task7 (Identity Builder+Reaper)
+                       │
+                       └── Task8 (编译验证) —— 最后执行
+```
+
+Task3/4/5 有严格顺序依赖。Task6/7 有严格顺序依赖。两组之间可并行。

--- a/docs/superpowers/specs/2026-05-21-es-mysql-consistency-design.md
+++ b/docs/superpowers/specs/2026-05-21-es-mysql-consistency-design.md
@@ -1,0 +1,148 @@
+# ES-MySQL 一致性设计
+
+**目标：** 解决 Conversation、Identity 服务 ES 写入静默失败导致的不一致，建立统一的 ES 写入可靠性模式，为未来 CDC 迁移留好接口。
+
+**原则：** 最终一致，ES 可落后 MySQL（秒级），但不允许永久性数据丢失。先防新增不一致，不管历史数据。
+
+---
+
+## 1. 现状分析
+
+### 1.1 ES 使用分布
+
+| 服务 | ES 索引 | 操作类型 | 写入模式 | 可靠性 |
+|------|--------|---------|---------|--------|
+| Message | `message` | UPSERT/DELETE | MQ 管道 + Outbox + Reaper | 好 |
+| Conversation | `chat_session` | UPSERT/DELETE/PARTIAL_UPDATE | 同步 fire-and-forget | 差 |
+| Identity | `user` | UPSERT | 同步 fire-and-forget（返回值被忽略） | 很差 |
+| Relationship | `user` | 只读搜索 | 不写 | — |
+
+### 1.2 问题根因
+
+- MySQL 先 commit，后写 ES，ES 失败无法回滚
+- Conversation：`append_data`/`remove`/`update_member_ids` 失败只打 bvar，RPC 正常返回
+- Identity：`append_data` 返回值完全忽略，没有任何感知
+- Message：MQ + DLX 重试 1 次后 `NackDiscard`，Reaper 每 5s 只拉 50 条，积压也可丢
+
+### 1.3 一致性路径
+
+```
+RPC Handler
+  → MySQL COMMIT                    // 成功，不可回滚
+  → ES 直写 (retry 3x, backoff)     // 本次新增
+  → 全部失败 → Redis Outbox        // 本次新增
+  → Outbox Reaper (每 5s)           // 从 message 扩展到全服务
+```
+
+---
+
+## 2. 整体架构
+
+### 2.1 写入模型
+
+| 服务 | 写入方式 | Outbox |
+|------|---------|--------|
+| Message | MQ 管道（保持现状） | Redis ESOutbox + Reaper |
+| Conversation | ES Client 直写 + 3 次重试 | Redis ESOutbox + Reaper |
+| Identity | ES Client 直写 + 3 次重试 | Redis ESOutbox + Reaper |
+| Relationship | 只读不写 | — |
+
+Conversation 和 Identity 写 ES 频率低（建群、加人、注册、改资料），不经过 MQ，直接写 ES。
+
+### 2.2 重试策略
+
+```
+尝试1: ES 直写 ──失败──→ 等待 100ms
+尝试2: ES 直写 ──失败──→ 等待 200ms
+尝试3: ES 直写 ──失败──→ 入 Redis Outbox，打 metrics
+                          ↓
+               Reaper(每5s) ──成功──→ 从 Outbox 删除
+                          ──失败──→ 保留，下次再试
+```
+
+### 2.3 Outbox
+
+- **存储：** Redis Sorted Set，key 按服务隔离：`im:es:outbox:conversation`、`im:es:outbox:identity`、`im:es:outbox:message`
+- **Payload：** `"index|doc_id|action|params..."` 字符串，同进程 Reaper 解析后重放对应的 ES 方法
+- **排序：** score = `created_at_ms`，FIFO 顺序重放
+- **Reaper：** 每个服务独立线程，etcd 选主，每 5s peek 50 条，直写 ES，成功 remove
+
+---
+
+## 3. 各服务改动
+
+### 3.1 Conversation 服务
+
+| 位置 | ES 操作 | 现状 | 改为 |
+|------|--------|------|------|
+| CreateConversation | UPSERT | `append_data(ent, members)` 不检查 | 重试 3 次 + Outbox |
+| UpdateConversation | UPSERT | `append_data(ent)` 不检查 | 重试 3 次 + Outbox |
+| DismissConversation | DELETE | `remove(cid)` 不检查 | 重试 3 次 + Outbox |
+| AddMembers | PARTIAL_UPDATE | `update_member_ids(cid, uids)` | 重试 3 次 + Outbox |
+| RemoveMembers | PARTIAL_UPDATE | 同上 | 重试 3 次 + Outbox |
+| QuitConversation | PARTIAL_UPDATE | 同上 | 重试 3 次 + Outbox |
+
+**新增组件：**
+- `ESWriteHelper`：封装重试逻辑 `retry_write_es(lambda, outbox_key, outbox_payload)`
+- 独立 Reaper 线程 + etcd leader 选举
+- 独立 `elasticlient::Client` 实例给 Reaper（避免和 RPC 线程竞争）
+
+### 3.2 Identity 服务
+
+| 位置 | ES 操作 | 现状 | 改为 |
+|------|--------|------|------|
+| Register | UPSERT | `append_data(...)` 返回忽略 | 重试 3 次 + Outbox |
+| UpdateProfile | UPSERT | 同上 | 同上 |
+
+**新增组件：** 同 Conversation 的 `ESWriteHelper` + Reaper。
+
+### 3.3 Message 服务
+
+不改。保持现有 MQ 管道 + Outbox + Reaper。
+
+### 3.4 Relationship 服务
+
+不改。只读 ES 不做写入。
+
+---
+
+## 4. 监控
+
+| 指标 | 来源 | 含义 |
+|------|------|------|
+| `g_degraded_es_write_total` | 已有 bvar | 进入 Outbox 的事件数 |
+| `g_es_retry_total` | 新增 bvar | 重试发生次数（含最终成功） |
+| `im:es:outbox:*` ZCARD | Redis | Outbox 积压量 |
+
+**告警规则：**
+- ZCARD > 1000 → ES 或网络异常，人为介入
+- `g_degraded_es_write_total` 持续增长 → Outbox 链路也堵了
+
+---
+
+## 5. 线程安全
+
+- `sw::redis++`：线程安全，Reaper 和 RPC 线程可共享 Redis Client
+- `elasticlient::Client`：未确认线程安全，Reaper 使用独立 Client 实例
+- `ESOutbox` 类：无锁，依赖 Redis Client 的线程安全
+
+---
+
+## 6. 未来 CDC 迁移
+
+当 Canal + binlog 上线时：
+
+1. Canal 监听业务表 binlog → 投递到现有 MQ exchange
+2. MQ Consumer 端不动（接受同样的 JSON payload）
+3. 应用层逐步去掉 `publish_confirm` 调用和 Outbox 写入
+4. Outbox 机制保留作为 Canal 故障时的兜底
+
+---
+
+## 7. 不在范围内
+
+- 历史数据对账修复
+- 统一 `ESIndexEvent` proto 格式（等 CDC 时再统一）
+- Message 服务链路修改
+- Relationship 服务（只读不写）
+- ES 索引重建工具

--- a/identity/source/identity_server.h
+++ b/identity/source/identity_server.h
@@ -637,16 +637,21 @@ public:
             const std::shared_ptr<elasticlient::Client> &es_client,
             const std::shared_ptr<odb::core::database> &mysql_client,
             const RedisClient::ptr &redis_client,
-            const std::shared_ptr<brpc::Server> &server)
+            const std::shared_ptr<brpc::Server> &server,
+            IdentityServiceImpl *impl)
         : _service_discover(service_discover),
         _reg_client(reg_client),
         _es_client(es_client),
         _mysql_client(mysql_client),
         _redis_client(redis_client),
-        _rpc_server(server) {}
-    ~IdentityServer() = default;
+        _rpc_server(server),
+        _impl(impl) {}
+    ~IdentityServer() {
+        if (_impl) _impl->stop_es_outbox_reaper();
+    }
     /* brief: 搭建RPC服务器，并启动服务器 */
     void start() {
+        if (_impl) _impl->start_es_outbox_reaper();
         _rpc_server->RunUntilAskedToQuit();
     }
 private:
@@ -656,6 +661,7 @@ private:
     std::shared_ptr<elasticlient::Client> _es_client;
     std::shared_ptr<odb::core::database> _mysql_client;
     RedisClient::ptr _redis_client;
+    IdentityServiceImpl* _impl = nullptr;
 };
 
 /* 建造者模式: 将对象真正的构造过程封装，便于后期扩展和调整 */
@@ -663,7 +669,10 @@ class IdentityServerBuilder
 {
 public:
     /* brief: 构造es客户端对象 */
-    void make_es_object(const std::vector<std::string> host_list) { _es_client = ESClientFactory::create(host_list); }
+    void make_es_object(const std::vector<std::string> host_list) {
+        _es_client = ESClientFactory::create(host_list);
+        _es_hosts = host_list;
+    }
     /* brief: 构造mysql客户端对象 */
     void make_mysql_object(const std::string &user,
                         const std::string &password,
@@ -691,6 +700,7 @@ public:
             auto redis = RedisClientFactory::create(host, port, db, keep_alive, pool_size);
             _redis_client = std::make_shared<RedisClient>(redis);
         }
+        _es_outbox = std::make_shared<ESOutbox>(_redis_client, "im:es:outbox:identity");
     }
     /* brief: 加载 JWT 配置并构造 codec / store（必须在 make_redis_object 之后） */
     void make_jwt_object(const std::string &auth_config_path) {
@@ -764,10 +774,17 @@ public:
             LOG_ERROR("还未初始化JWT模块（缺 make_jwt_object）");
             abort();
         }
+        if(!_es_outbox) {
+            LOG_ERROR("还未初始化ESOutbox");
+            abort();
+        }
 
+        auto es_reaper_client = ESClientFactory::create(_es_hosts);
         IdentityServiceImpl *identity_service = new IdentityServiceImpl(
             _mysql_client, _es_client, _redis_client, _mail_client,
-            _jwt_codec, _jwt_store, _media_public_url_prefix);
+            _jwt_codec, _jwt_store, _media_public_url_prefix,
+            _es_outbox, es_reaper_client);
+        _service_impl = identity_service;
         int ret = _rpc_server->AddService(identity_service, brpc::ServiceOwnership::SERVER_OWNS_SERVICE);
         if(ret == -1) {
             LOG_ERROR("添加IdentityService RPC服务失败!");
@@ -798,7 +815,8 @@ public:
         }
 
         IdentityServer::ptr server = std::make_shared<IdentityServer>(
-            _service_discover, _reg_client, _es_client, _mysql_client, _redis_client, _rpc_server);
+            _service_discover, _reg_client, _es_client, _mysql_client, _redis_client,
+            _rpc_server, _service_impl);
         return server;
     }
 private:
@@ -817,6 +835,9 @@ private:
     std::shared_ptr<::chatnow::auth::JwtStore> _jwt_store;
 
     std::shared_ptr<brpc::Server> _rpc_server;
+    ESOutbox::ptr                           _es_outbox;
+    std::vector<std::string>                _es_hosts;
+    IdentityServiceImpl*                    _service_impl = nullptr;
 };
 
 }

--- a/identity/source/identity_server.h
+++ b/identity/source/identity_server.h
@@ -7,6 +7,9 @@
 #include "dao/data_es.hpp"      // es数据管理客户端封装
 #include "dao/mysql_user.hpp"   // mysql数据管理客户端封装
 #include "dao/data_redis.hpp"   // redis数据管理客户端封装
+#include "infra/metrics.hpp"
+#include <thread>
+#include <chrono>
 #include "common/types.pb.h"
 #include "common/error.pb.h"
 #include "common/envelope.pb.h"
@@ -39,19 +42,72 @@ public:
                         const std::shared_ptr<MailClient> &mail_client,
                         const std::shared_ptr<auth::JwtCodec> &jwt_codec,
                         const std::shared_ptr<auth::JwtStore> &jwt_store,
-                        const std::string &media_public_url_prefix)
+                        const std::string &media_public_url_prefix,
+                        const ESOutbox::ptr &es_outbox,
+                        const std::shared_ptr<elasticlient::Client> &es_reaper_client)
         : _mysql_user(std::make_shared<UserTable>(mysql_client)),
           _es_user(std::make_shared<ESUser>(es_client)),
           _redis_codes(std::make_shared<Codes>(redis_client)),
           _mail_client(mail_client),
           _jwt_codec(jwt_codec),
           _jwt_store(jwt_store),
-          _media_public_url_prefix(media_public_url_prefix)
+          _media_public_url_prefix(media_public_url_prefix),
+          _es_outbox(es_outbox),
+          _es_user_reaper(std::make_shared<ESUser>(es_reaper_client))
     {
         _es_user->create_index();
     }
 
     ~IdentityServiceImpl() override = default;
+
+    void start_es_outbox_reaper() {
+        _es_reaper_running = std::make_shared<std::atomic<bool>>(true);
+        _es_reaper_thread = std::make_shared<std::thread>([this]() {
+            while (*_es_reaper_running) {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+                try {
+                    auto items = _es_outbox->peek(50);
+                    for (const auto &item : items) {
+                        if (replay_es_write_(item))
+                            _es_outbox->remove(item);
+                    }
+                } catch (std::exception &e) {
+                    LOG_WARN("ESOutbox reaper 异常: {}", e.what());
+                }
+            }
+        });
+    }
+
+    void stop_es_outbox_reaper() {
+        if (_es_reaper_running) *_es_reaper_running = false;
+        if (_es_reaper_thread && _es_reaper_thread->joinable())
+            _es_reaper_thread->join();
+    }
+
+    bool replay_es_write_(const std::string &payload) {
+        if (!_es_user_reaper) {
+            LOG_ERROR("ESOutbox replay: _es_user_reaper is null");
+            return false;
+        }
+        Json::Value root;
+        if (!UnSerialize(payload, root)) {
+            LOG_WARN("ESOutbox replay: failed to parse payload");
+            return false;
+        }
+        std::string op = root.get("op", "").asString();
+        if (op == "upsert") {
+            return _es_user_reaper->append_data(
+                root.get("uid", "").asString(),
+                root.get("mail", "").asString(),
+                root.get("phone", "").asString(),
+                root.get("nick", "").asString(),
+                root.get("desc", "").asString(),
+                root.get("avatar", "").asString(),
+                root.get("status", 0).asInt());
+        }
+        LOG_WARN("ESOutbox replay: unknown op '{}'", op);
+        return false;
+    }
 
     /* brief: IdentityService.Login —— 用户名密码登录，签发 access+refresh */
     void Login(::google::protobuf::RpcController* controller,
@@ -272,7 +328,11 @@ public:
                     throw ServiceError(::chatnow::error::kSystemInternalError,
                                        "db insert failed");
                 }
-                _es_user->append_data(user_id, "", phone, nickname, "", "");
+                std::string ob_payload = outbox_payload_upsert_(
+                    user_id, "", phone, nickname, "", "", 0);
+                retry_es_write_(ob_payload, [&]() {
+                    return _es_user->append_data(user_id, "", phone, nickname, "", "");
+                });
             } else if (request->has_phone_code()) {
                 throw ServiceError(::chatnow::error::kNotImplemented,
                                    "phone_code register not yet supported");
@@ -418,9 +478,15 @@ public:
                 throw ServiceError(::chatnow::error::kSystemInternalError,
                                    "db update failed");
             }
-            _es_user->append_data(user->user_id(), user->mail(), user->phone(),
-                                  user->nickname(), user->description(),
-                                  user->avatar_id());
+            std::string ob_payload = outbox_payload_upsert_(
+                user->user_id(), user->mail(), user->phone(),
+                user->nickname(), user->description(),
+                user->avatar_id(), 0);
+            retry_es_write_(ob_payload, [&]() {
+                return _es_user->append_data(user->user_id(), user->mail(), user->phone(),
+                                             user->nickname(), user->description(),
+                                             user->avatar_id());
+            });
             fill_user_info(response->mutable_user_info(), *user);
         });
     }
@@ -470,6 +536,50 @@ private:
     std::shared_ptr<auth::JwtCodec>     _jwt_codec;
     std::shared_ptr<auth::JwtStore>     _jwt_store;
     std::string                         _media_public_url_prefix;
+    ESOutbox::ptr                          _es_outbox;
+    std::shared_ptr<ESUser>                _es_user_reaper;
+    std::shared_ptr<std::atomic<bool>>     _es_reaper_running;
+    std::shared_ptr<std::thread>           _es_reaper_thread;
+
+    bool retry_es_write_(const std::string &outbox_payload,
+                         std::function<bool()> es_op)
+    {
+        for (int i = 0; i < 3; ++i) {
+            if (es_op()) return true;
+            if (i < 2) {
+                metrics::g_es_retry_total << 1;
+                std::this_thread::sleep_for(std::chrono::milliseconds(100 * (1 << i)));
+            }
+        }
+        if (_es_outbox) {
+            auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            _es_outbox->enqueue(outbox_payload, static_cast<long long>(now_ms));
+        }
+        metrics::g_degraded_es_write_total << 1;
+        return false;
+    }
+
+    static std::string outbox_payload_upsert_(const std::string &uid,
+                                               const std::string &mail,
+                                               const std::string &phone,
+                                               const std::string &nickname,
+                                               const std::string &description,
+                                               const std::string &avatar_id,
+                                               int status) {
+        Json::Value root;
+        root["op"] = "upsert";
+        root["uid"] = uid;
+        root["mail"] = mail;
+        root["phone"] = phone;
+        root["nick"] = nickname;
+        root["desc"] = description;
+        root["avatar"] = avatar_id;
+        root["status"] = status;
+        std::string dst;
+        Serialize(root, dst);
+        return dst;
+    }
 
     // ---- 输入校验 ----
     static bool nickname_check(const std::string &nickname) {


### PR DESCRIPTION
## Summary

为 Conversation 和 Identity 服务引入 ES-MySQL 最终一致性保障机制，防止 ES 写入失败导致索引数据丢失。

### 核心设计

- **热路径**：直接写 ES，3 次重试（100ms / 200ms 指数退避）
- **冷路径（兜底）**：重试全部失败后落入 Redis Outbox（ZSET），由 Reaper 线程定时补投
- **Fail-soft**：ES 失败不阻塞 RPC 响应返回
- **线程安全**：Reaper 持有独立 ES Client 实例

### 变更内容

**基础设施 (`common/`)**
- `ESOutbox` 支持自定义 Redis key，实现按服务隔离（`im:es:outbox:conversation` / `im:es:outbox:identity`）
- 新增 `g_es_retry_total` bvar 计数器

**Conversation 服务**
- `retry_es_write_`：3 次重试 + Outbox 兜底
- `outbox_payload_upsert_` / `outbox_payload_delete_` / `outbox_payload_upd_members_`：JSON 序列化
- `replay_es_write_`：Reaper 回放逻辑（含 null guard + 日志）
- `start_es_outbox_reaper` / `stop_es_outbox_reaper`：Reaper 生命周期
- 6 个写站点全部从 fire-and-forget 改为 retry+outbox 模式
- Builder 集成：创建 Outbox + Reaper ES Client，注入 ServiceImpl

**Identity 服务**
- 同 Conversation 模式
- `Register` / `UpdateProfile` 两个写站点接入 retry+outbox
- Builder 集成

**策略**
- Message 服务保持现有 MQ 管道不变
- Relationship 服务只读 ES，不涉及

## Test Plan
- [ ] CI 编译通过（需 Linux + ODB）
- [ ] CreateConversation → 故意 ES 不可达 → 确认 Outbox 有记录 → Reaper 补投成功
- [ ] Register → 同上流程
- [ ] 重试计数器 `g_es_retry_total` 正常递增